### PR TITLE
For koji, use http links, not https.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/buildsys.py
@@ -23,7 +23,7 @@ from fedmsg.meta.base import BaseProcessor
 class KojiProcessor(BaseProcessor):
     __name__ = "buildsys"
     __description__ = "the Fedora build system"
-    __link__ = "https://koji.fedoraproject.org/koji"
+    __link__ = "http://koji.fedoraproject.org/koji"
     __docs__ = "https://fedoraproject.org/wiki/Using_the_Koji_build_system"
     __obj__ = "Koji Builds"
     __icon__ = "http://fedoraproject.org/w/uploads/2/20/" + \
@@ -104,19 +104,19 @@ class KojiProcessor(BaseProcessor):
 
     def link(self, msg, **config):
         if 'buildsys.tag' in msg['topic']:
-            return "https://koji.fedoraproject.org/koji/taginfo?tagID=%i" % (
+            return "http://koji.fedoraproject.org/koji/taginfo?tagID=%i" % (
                 msg['msg']['tag_id'])
         elif 'buildsys.untag' in msg['topic']:
-            return "https://koji.fedoraproject.org/koji/taginfo?tagID=%i" % (
+            return "http://koji.fedoraproject.org/koji/taginfo?tagID=%i" % (
                 msg['msg']['tag_id'])
         elif 'buildsys.repo.init' in msg['topic']:
-            return "https://koji.fedoraproject.org/koji/taginfo?tagID=%i" % (
+            return "http://koji.fedoraproject.org/koji/taginfo?tagID=%i" % (
                 msg['msg']['tag_id'])
         elif 'buildsys.repo.done' in msg['topic']:
-            return "https://koji.fedoraproject.org/koji/taginfo?tagID=%i" % (
+            return "http://koji.fedoraproject.org/koji/taginfo?tagID=%i" % (
                 msg['msg']['tag_id'])
         elif 'buildsys.build.state.change' in msg['topic']:
-            return "https://koji.fedoraproject.org/koji/buildinfo?buildID=%i" \
+            return "http://koji.fedoraproject.org/koji/buildinfo?buildID=%i" \
                 % (msg['msg']['build_id'])
         else:
             raise NotImplementedError()


### PR DESCRIPTION
dgilmore suggested that we use http urls, not https (since koji has a self-signed certificate.. end-users are going to get a big ugly warning message).

Any comments?
