### PR TITLE
Use https for compose messages, not http.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/compose.py
+++ b/fedmsg_meta_fedora_infrastructure/compose.py
@@ -23,8 +23,8 @@ from fedmsg.meta.base import BaseProcessor
 class ComposeProcessor(BaseProcessor):
     __name__ = "compose"
     __description__ = "Fedora Release Engineering"
-    __link__ = "http://git.fedorahosted.org/cgit/releng"
-    __docs__ = "http://fedoraproject.org/wiki/ReleaseEngineering"
+    __link__ = "https://git.fedorahosted.org/cgit/releng"
+    __docs__ = "https://fedoraproject.org/wiki/ReleaseEngineering"
     __obj__ = "Composes"
 
     def subtitle(self, msg, **config):
@@ -58,7 +58,7 @@ class ComposeProcessor(BaseProcessor):
         return tmpl.format(branch=branch)
 
     def link(self, msg, **config):
-        base = "http://alt.fedoraproject.org/pub/fedora/linux/development"
+        base = "https://alt.fedoraproject.org/pub/fedora/linux/development"
         if 'rawhide' in msg['topic']:
             return base + "/rawhide"
         else:

--- a/fedmsg_meta_fedora_infrastructure/tests/__init__.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/__init__.py
@@ -243,7 +243,7 @@ class TestComposeBranchedComplete(Base):
     expected_title = "compose.branched.complete (unsigned)"
     expected_subti = "branched compose completed"
     expected_link = \
-        "http://alt.fedoraproject.org/pub/fedora/linux/development"
+        "https://alt.fedoraproject.org/pub/fedora/linux/development"
     expected_objects = set(['branched'])
     msg = {
         "i": 1,
@@ -323,7 +323,7 @@ class TestComposeBranchedRsyncComplete(Base):
     expected_subti = \
         "finished rsync of branched compose for public consumption"
     expected_link = \
-        "http://alt.fedoraproject.org/pub/fedora/linux/development"
+        "https://alt.fedoraproject.org/pub/fedora/linux/development"
     expected_objects = set(['branched'])
     msg = {
         "i": 1,
@@ -336,7 +336,7 @@ class TestComposeRawhideComplete(Base):
     expected_title = "compose.rawhide.complete (unsigned)"
     expected_subti = "rawhide compose completed"
     expected_link = \
-        "http://alt.fedoraproject.org/pub/fedora/linux/development/rawhide"
+        "https://alt.fedoraproject.org/pub/fedora/linux/development/rawhide"
     expected_objects = set(['rawhide'])
     msg = {
         "i": 1,
@@ -393,7 +393,7 @@ class TestComposeRawhideRsyncComplete(Base):
     expected_title = "compose.rawhide.rsync.complete (unsigned)"
     expected_subti = "finished rsync of rawhide compose for public consumption"
     expected_link = \
-        "http://alt.fedoraproject.org/pub/fedora/linux/development/rawhide"
+        "https://alt.fedoraproject.org/pub/fedora/linux/development/rawhide"
     expected_objects = set(['rawhide'])
     msg = {
         "i": 1,


### PR DESCRIPTION
Unlike #2, use https for download links instead of http.
