### PR TITLE
Standardize absence of "object" prefix.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/askbot.py
+++ b/fedmsg_meta_fedora_infrastructure/askbot.py
@@ -107,15 +107,15 @@ class AskbotProcessor(BaseProcessor):
             for tag in msg['msg']['tags']:
                 if not tag:
                     continue
-                objs.add('askbot/tags/{tag}'.format(tag=tag))
+                objs.add('tags/{tag}'.format(tag=tag))
         elif 'thread' in msg['msg']:
             for tag in msg['msg']['thread']['tagnames']:
                 if not tag:
                     continue
-                objs.add('askbot/tags/{tag}'.format(tag=tag))
+                objs.add('tags/{tag}'.format(tag=tag))
 
         if 'thread' in msg['msg']:
-            objs.add('askbot/threads/{pk}'.format(
+            objs.add('threads/{pk}'.format(
                 pk=msg['msg']['thread']['pk']))
 
         return objs

--- a/fedmsg_meta_fedora_infrastructure/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/buildsys.py
@@ -132,49 +132,49 @@ class KojiProcessor(BaseProcessor):
         if 'buildsys.tag' in msg['topic']:
             return set([
                 '/'.join([
-                    'koji', 'builds',
+                    'builds',
                     msg['msg']['name'],
                     msg['msg']['version'],
                     msg['msg']['release'],
                 ]),
                 '/'.join([
-                    'koji', 'tags',
+                    'tags',
                     msg['msg']['tag'],
                 ]),
             ])
         elif 'buildsys.untag' in msg['topic']:
             return set([
                 '/'.join([
-                    'koji', 'builds',
+                    'builds',
                     msg['msg']['name'],
                     msg['msg']['version'],
                     msg['msg']['release'],
                 ]),
                 '/'.join([
-                    'koji', 'tags',
+                    'tags',
                     msg['msg']['tag'],
                 ]),
             ])
         elif 'buildsys.build.state.change' in msg['topic']:
             return set(['/'.join([
-                'koji', 'builds',
+                'builds',
                 msg['msg']['name'],
                 msg['msg']['version'],
                 msg['msg']['release'],
             ])])
         elif 'buildsys.repo.init' in msg['topic']:
             return set(['/'.join([
-                'koji', 'repos',
+                'repos',
                 msg['msg']['tag'],
             ])])
         elif 'buildsys.repo.done' in msg['topic']:
             return set(['/'.join([
-                'koji', 'repos',
+                'repos',
                 msg['msg']['tag'],
             ])])
         elif 'buildsys.package.list.change' in msg['topic']:
             return set(['/'.join([
-                'koji', 'tags',
+                'tags',
                 msg['msg']['tag'],
             ])])
         else:

--- a/fedmsg_meta_fedora_infrastructure/tests/askbot.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/askbot.py
@@ -33,10 +33,10 @@ class TestAskbotRetag(Base):
     expected_packages = set()
     expected_usernames = set(['ralph'])
     expected_objects = set([
-        'askbot/tags/asldkjfalskdjfalskj',
-        'askbot/tags/asldkjf',
-        'askbot/tags/asldkjfalskdjf',
-        'askbot/threads/2',
+        'tags/asldkjfalskdjfalskj',
+        'tags/asldkjf',
+        'tags/asldkjfalskdjf',
+        'threads/2',
     ])
     expected_link = "https://ask.fedoraproject.org/question/2/"
     msg = {
@@ -76,8 +76,8 @@ class TestAskbotNewQuestion(Base):
     expected_packages = set()
     expected_usernames = set(['ralph'])
     expected_objects = set([
-        'askbot/tags/lolol',
-        'askbot/threads/3',
+        'tags/lolol',
+        'threads/3',
     ])
     expected_link = "https://ask.fedoraproject.org/question/3/"
     msg = {
@@ -125,8 +125,8 @@ class TestAskbotNewAnswer(Base):
     expected_packages = set()
     expected_usernames = set(['ralph', 'lmacken'])
     expected_objects = set([
-        'askbot/tags/cool',
-        'askbot/threads/1',
+        'tags/cool',
+        'threads/1',
     ])
     expected_link = "https://ask.fedoraproject.org/question/1/"
     msg = {
@@ -173,9 +173,9 @@ class TestAskbotFlagOffensiveAdd(Base):
     expected_packages = set()
     expected_usernames = set(['ralph'])
     expected_objects = set([
-        'askbot/tags/town',
-        'askbot/tags/ohok',
-        'askbot/threads/2',
+        'tags/town',
+        'tags/ohok',
+        'threads/2',
     ])
     expected_link = "https://ask.fedoraproject.org/question/2/"
     msg = {
@@ -218,9 +218,9 @@ class TestAskbotFlagOffensiveRemove(Base):
     expected_packages = set()
     expected_usernames = set(['ralph'])
     expected_objects = set([
-        'askbot/tags/town',
-        'askbot/tags/ohok',
-        'askbot/threads/2',
+        'tags/town',
+        'tags/ohok',
+        'threads/2',
     ])
     expected_link = "https://ask.fedoraproject.org/question/2/"
     msg = {
@@ -263,8 +263,8 @@ class TestAskbotUpdatedQuestion(Base):
     expected_packages = set()
     expected_usernames = set(['ralph'])
     expected_objects = set([
-        'askbot/tags/town',
-        'askbot/threads/3',
+        'tags/town',
+        'threads/3',
     ])
     expected_link = "https://ask.fedoraproject.org/question/" + \
         "2/?answer=2#post-id-2"
@@ -310,8 +310,8 @@ class TestAskbotUpdatedQuestion(Base):
     expected_packages = set()
     expected_usernames = set(['ralph'])
     expected_objects = set([
-        'askbot/tags/lolol',
-        'askbot/threads/3',
+        'tags/lolol',
+        'threads/3',
     ])
     expected_link = "https://ask.fedoraproject.org/question/3/"
     msg = {
@@ -356,7 +356,7 @@ class TestAskbotAnswerDeleted(Base):
     expected_packages = set()
     expected_usernames = set(['ralph'])
     expected_objects = set([
-        'askbot/threads/7',
+        'threads/7',
     ])
     expected_link = "https://ask.fedoraproject.org/question/10/"
     msg = {
@@ -396,7 +396,7 @@ class TestAskbotQuestionDeleted(Base):
     expected_packages = set()
     expected_usernames = set(['ralph'])
     expected_objects = set([
-        'askbot/threads/7',
+        'threads/7',
     ])
     expected_link = "https://ask.fedoraproject.org/question/10/"
     msg = {

--- a/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
@@ -33,8 +33,8 @@ class TestKojiBuildTag(Base):
     expected_packages = set(['stage'])
     expected_usernames = set(['ralph', 'bodhi'])
     expected_objects = set([
-        'koji/builds/stage/4.1.1/3.fc18',
-        'koji/tags/f18-updates-testing-pending',
+        'builds/stage/4.1.1/3.fc18',
+        'tags/f18-updates-testing-pending',
     ])
     expected_link = "http://koji.fedoraproject.org/koji/" + \
         "taginfo?tagID=216"
@@ -64,8 +64,8 @@ class TestKojiBuildUnTag(Base):
     expected_packages = set(['globus-gram-job-manager-sge'])
     expected_usernames = set(['ralph', 'bodhi'])
     expected_objects = set([
-        'koji/builds/globus-gram-job-manager-sge/1.5/2.fc16',
-        'koji/tags/f16-updates-pending',
+        'builds/globus-gram-job-manager-sge/1.5/2.fc16',
+        'tags/f16-updates-pending',
     ])
     expected_link = "http://koji.fedoraproject.org/koji/" + \
         "taginfo?tagID=216"
@@ -94,7 +94,7 @@ class TestKojiBuildStateChangeStart(Base):
     expected_usernames = set(['ralph'])
     expected_packages = set(['eclipse-ptp'])
     expected_objects = set([
-        'koji/builds/eclipse-ptp/6.0.3/1.fc19'
+        'builds/eclipse-ptp/6.0.3/1.fc19'
     ])
     expected_link = "http://koji.fedoraproject.org/koji/" + \
         "buildinfo?buildID=12345"
@@ -124,7 +124,7 @@ class TestKojiBuildStateChangeFail(Base):
     expected_packages = set(['eclipse-ptp'])
     expected_usernames = set(['rmattes'])
     expected_objects = set([
-        'koji/builds/eclipse-ptp/6.0.3/1.fc19',
+        'builds/eclipse-ptp/6.0.3/1.fc19',
     ])
     expected_link = "http://koji.fedoraproject.org/koji/" + \
         "buildinfo?buildID=12345"
@@ -154,7 +154,7 @@ class TestKojiRepoInit(Base):
     expected_packages = set([])
     expected_usernames = set([])
     expected_objects = set([
-        'koji/repos/f19-build',
+        'repos/f19-build',
     ])
     expected_link = "http://koji.fedoraproject.org/koji/" + \
         "taginfo?tagID=12345"
@@ -179,7 +179,7 @@ class TestKojiRepoDone(Base):
     expected_packages = set([])
     expected_usernames = set([])
     expected_objects = set([
-        'koji/repos/f19-build',
+        'repos/f19-build',
     ])
     expected_link = "http://koji.fedoraproject.org/koji/" + \
         "taginfo?tagID=12345"
@@ -204,7 +204,7 @@ class TestKojiPackageListChange(Base):
     expected_packages = set(["almanah"])
     expected_usernames = set([])
     expected_objects = set([
-        'koji/tags/f17',
+        'tags/f17',
     ])
     msg = {
         "topic": "org.fedoraproject.prod.buildsys.package.list.change",


### PR DESCRIPTION
The set of "objects" returned from msg2objects is inconsistent.  Some processors prefix their objects with their own `__name__` or "modname" and others do not.

Here we standardize it so that all processors return their objects with no prefix.  It doesn't really matter if there is a prefix or not, just so long as they are consistent.

The "objects" sets are used primarily for gource visualization and are not very important.
