### PR TITLE
Handle topic changes from meetbot.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/supybot.py
+++ b/fedmsg_meta_fedora_infrastructure/supybot.py
@@ -41,14 +41,22 @@ class SupybotProcessor(BaseProcessor):
                 tmpl = self._('{user} ended meeting "{name}" in {channel}')
             else:
                 tmpl = self._('{user} ended a meeting in {channel}')
+        elif 'meetbot.meeting.topic.update' in msg['topic']:
+            if msg['msg']['meeting_topic']:
+                tmpl = self._('{user} changed the topic of '
+                              '"{name}" to "{topic}" in {channel}')
+            else:
+                tmpl = self._('{user} changed the topic '
+                              'to "{topic}" in {channel}')
         else:
             raise NotImplementedError("%r" % msg)
 
         user = msg['msg']['owner']
         name = msg['msg']['meeting_topic']
         channel = msg['msg']['channel']
+        topic = msg['msg'].get('topic', 'no topic')
 
-        return tmpl.format(user=user, name=name, channel=channel)
+        return tmpl.format(user=user, name=name, channel=channel, topic=topic)
 
     def usernames(self, msg, **config):
         return set(msg['msg']['attendees'].keys())
@@ -63,5 +71,8 @@ class SupybotProcessor(BaseProcessor):
 
         if msg['msg']['meeting_topic']:
             objs.add('titles/' + msg['msg']['meeting_topic'])
+
+        if msg['msg'].get('topic', None):
+            objs.add('topics/' + msg['msg']['topic'])
 
         return objs

--- a/fedmsg_meta_fedora_infrastructure/tests/__init__.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/__init__.py
@@ -987,6 +987,69 @@ class TestSupybotEndMeetingNoTitle(Base):
     }
 
 
+class TestSupybotChangeTopic(Base):
+    expected_title = "meetbot.meeting.topic.update (unsigned)"
+    expected_subti = 'threebean changed the topic of "title" to "Food" in #channel'
+    expected_link = 'http://logs.com/awesome.html'
+    expected_usernames = set(['threebean', 'fedmsg-test-bot'])
+    expected_objects = set([
+        'attendees/fedmsg-test-bot',
+        'attendees/threebean',
+        'channels/#channel',
+        'titles/title',
+        'topics/Food',
+    ])
+
+    msg = {
+        "i": 16,
+        "msg": {
+            "meeting_topic": "title",
+            "attendees": {
+                "fedmsg-test-bot": 2,
+                "threebean": 2
+            },
+            "chairs": {},
+            "url": "http://logs.com/awesome",
+            "owner": "threebean",
+            "channel": "#channel",
+            "topic": "Food",
+        },
+        "topic": "org.fedoraproject.dev.meetbot.meeting.topic.update",
+        "timestamp": 1345572862.556145
+    }
+
+
+class TestSupybotChangeTopicNoTitle(Base):
+    expected_title = "meetbot.meeting.topic.update (unsigned)"
+    expected_subti = 'threebean changed the topic to "Food" in #channel'
+    expected_link = 'http://logs.com/awesome.html'
+    expected_usernames = set(['threebean', 'fedmsg-test-bot'])
+    expected_objects = set([
+        'attendees/fedmsg-test-bot',
+        'attendees/threebean',
+        'channels/#channel',
+        'topics/Food'
+    ])
+
+    msg = {
+        "i": 16,
+        "msg": {
+            "meeting_topic": None,
+            "attendees": {
+                "fedmsg-test-bot": 2,
+                "threebean": 2
+            },
+            "chairs": {},
+            "url": "http://logs.com/awesome",
+            "owner": "threebean",
+            "channel": "#channel",
+            "topic": "Food",
+        },
+        "topic": "org.fedoraproject.dev.meetbot.meeting.topic.update",
+        "timestamp": 1345572862.556145
+    }
+
+
 class TestTaggerVoteAnonymous(Base):
     expected_title = "fedoratagger.tag.update (unsigned)"
     expected_subti = 'anonymous upvoted "unittest" on perl-Test-Fatal'


### PR DESCRIPTION
Meetbot has been emitting messages on meeting-topic changes for **months**.  I didn't realize fedmsg.meta didn't support it until just now.
