### PR TITLE
[mediawiki] Nuke a '.' for consistency in subtitles.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/mediawiki.py
+++ b/fedmsg_meta_fedora_infrastructure/mediawiki.py
@@ -33,7 +33,7 @@ class WikiProcessor(BaseProcessor):
         if 'wiki.article.edit' in msg['topic']:
             user = msg['msg']['user']
             title = msg['msg']['title']
-            tmpl = self._('{user} made a wiki edit to "{title}".')
+            tmpl = self._('{user} made a wiki edit to "{title}"')
             return tmpl.format(user=user, title=title)
         elif 'wiki.upload.complete' in msg['topic']:
             user = msg['msg']['user_text']


### PR DESCRIPTION
None of the other subtitles have it.
