### PR TITLE
@laarmen asked in #fedora-apps if we could invert the msg2emails dict to...

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/__init__.py
+++ b/fedmsg_meta_fedora_infrastructure/__init__.py
@@ -10,7 +10,7 @@ class BaseProcessor(fedmsg.meta.base.BaseProcessor):
     def emails(self, msg, **config):
         usernames = self.usernames(msg, **config)
         emails = [name + "@fedoraproject.org" for name in usernames]
-        return dict(zip(usernames, emails))
+        return dict(zip(emails, usernames))
 
     def avatars(self, msg, **config):
         usernames = self.usernames(msg, **config)

--- a/fedmsg_meta_fedora_infrastructure/tests/askbot.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/askbot.py
@@ -294,7 +294,7 @@ class TestAskbotUpdatedQuestion(Base):
         "fedoraproject.org%2Fstatic%2Fimages%2Ffedora_infinity_64x64.png"
     expected_packages = set()
     expected_usernames = set(['ralph'])
-    expected_emails = dict(ralph='ralph@fedoraproject.org')
+    expected_emails = {'ralph@fedoraproject.org': 'ralph'}
     expected_avatars = dict(ralph="http://www.gravatar.com/avatar/" + \
         "2f933f4364baaabd2d3ab8f0664faef2?s=64&d=http%3A%2F%2F" + \
         "fedoraproject.org%2Fstatic%2Fimages%2Ffedora_infinity_64x64.png")


### PR DESCRIPTION
... make things easier for email-centric debian infrastructure.
