### PR TITLE
Only return meetbot links when the meeting is actually over.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/supybot.py
+++ b/fedmsg_meta_fedora_infrastructure/supybot.py
@@ -32,7 +32,10 @@ class SupybotProcessor(BaseProcessor):
     __obj__ = "IRC Meetings"
 
     def link(self, msg, **config):
-        return msg['msg']['url'] + ".html"
+        if 'meetbot.meeting.complete' in msg['topic']:
+            return msg['msg']['url'] + ".html"
+        else:
+            return None
 
     def subtitle(self, msg, **config):
         if 'meetbot.meeting.start' in msg['topic']:

--- a/fedmsg_meta_fedora_infrastructure/tests/__init__.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/__init__.py
@@ -987,7 +987,6 @@ class TestSupybotChangeTopic(Base):
     """
     expected_title = "meetbot.meeting.topic.update"
     expected_subti = 'ralph changed the topic of "title" to "Food" in #channel'
-    expected_link = 'http://logs.com/awesome.html'
     expected_usernames = set(['ralph'])
     expected_objects = set([
         'attendees/ralph',
@@ -1022,7 +1021,6 @@ class TestSupybotChangeTopicNoTitle(Base):
     """
     expected_title = "meetbot.meeting.topic.update"
     expected_subti = 'ralph changed the topic to "Food" in #channel'
-    expected_link = 'http://logs.com/awesome.html'
     expected_usernames = set(['ralph'])
     expected_objects = set([
         'attendees/ralph',


### PR DESCRIPTION
For people using the desktop notification tool, they get a link popup when a meeting starts.  However, that link goes nowhere, since the meeting minutes haven't been synced over yet.

This patch restricts us so we only return a link for when the meeting is actually over.
