### PR TITLE
Legacy support - old bodhi messages don't have this field.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/bodhi.py
+++ b/fedmsg_meta_fedora_infrastructure/bodhi.py
@@ -35,7 +35,7 @@ class BodhiProcessor(BaseProcessor):
     __link__ = "https://admin.fedoraproject.org/updates"
     __docs__ = "http://fedoraproject.org/wiki/Bodhi"
     __obj__ = "Package Updates"
-    __icon__ = ("https://admin.fedoraproject.org/updates" 
+    __icon__ = ("https://admin.fedoraproject.org/updates"
                 "/static/images/bodhi-icon-48.png")
 
     def secondary_icon(self, msg, **config):
@@ -74,7 +74,7 @@ class BodhiProcessor(BaseProcessor):
             return tmpl.format(author=author, package=package, status=status)
         elif 'bodhi.update.request' in msg['topic']:
             status = msg['topic'].split('.')[-1]
-            author = msg['msg']['agent']
+            author = msg['msg'].get('agent')
             title = msg['msg']['update']['title']
             if status in ('unpush', 'obsolete', 'revoke'):
                 # make our status past-tense


### PR DESCRIPTION
This is so that we can still process old entires in datanommer.
