### PR TITLE
Remove "slave" field from jenkins

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/jenkins.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/jenkins.py
@@ -46,7 +46,6 @@ class TestJenkinsBuildStart(Base):
         u'topic': u'org.fedoraproject.prod.jenkins.build.start',
         u'msg': {
             u'project': 'fedora-mobile',
-            u'slave': u'Fedora18',
             u'build': 174,
         },
     }
@@ -73,7 +72,6 @@ class TestJenkinsBuildPassed(Base):
         u'msg': {
             u'project': 'fedora-mobile',
             u'took': u'1 min 28 sec',
-            u'slave': u'Fedora18',
             u'build': 174,
         },
     }
@@ -100,7 +98,6 @@ class TestJenkinsBuildFailed(Base):
         u'msg': {
             u'project': 'fedora-mobile',
             u'took': u'9.4 sec',
-            u'slave': u'Fedora18',
             u'build': 165,
         },
     }


### PR DESCRIPTION
I can't easily get the hostname from the plugin infrastructure, from
what I can see, so I am going to remove these fields for now.
