### PR TITLE
Two different changes

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/github.py
+++ b/fedmsg_meta_fedora_infrastructure/github.py
@@ -121,7 +121,7 @@ class GithubProcessor(BaseProcessor):
             return tmpl.format(user=user, repo=repo)
         elif 'github.status' in msg['topic']:
             description = msg['msg']['description']
-            sha = msg['msg']['sha']
+            sha = msg['msg']['sha'][:8]
             tmpl = self._("{description} for {repo} {sha}")
             return tmpl.format(description=description, repo=repo, sha=sha)
         else:

--- a/fedmsg_meta_fedora_infrastructure/tests/github.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/github.py
@@ -891,7 +891,7 @@ class TestGithubStatus(Base):
 
     expected_title = "github.status"
     expected_subti = 'PEP8Bot scan pending for fedora-infra/datanommer ' + \
-        'e71e2ba93fa992d9026f89d65f9220d5234bfab1'
+        'e71e2ba9'
     expected_link = "http://pep8.me/fedora-infra/datanommer/commits" + \
         "/e71e2ba93fa992d9026f89d65f9220d5234bfab1"
     expected_icon = "https://apps.fedoraproject.org/img/icons/github.png"


### PR DESCRIPTION
- Use short hashes for github messages just to make them nicer and more
  readble.
- Also, protect against some cases where None shows up in a value instead of a
  nested dict.
