### PR TITLE
Add meta code for fedimg.image.test topic

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -30,18 +30,35 @@ class FedimgProcessor(BaseProcessor):
     __obj__ = "New cloud image upload"
 
     def subtitle(self, msg, **config):
-        if msg['msg']['status'] is "started":
-            name = msg['msg']['image_name']
-            dest = msg['msg']['destination']
-            tmpl = self._('Image {image_name} started uploading to {dest}')
-            return tmpl.format(image_name=name, dest=dest)
-        elif msg['msg']['status'] is "completed":
-            name = msg['msg']['image_name']
-            dest = msg['msg']['destination']
-            tmpl = self._('Image {image_name} finished uploading to to {dest}')
-            return tmpl.format(image_name=name, dest=dest)
-        elif msg['msg']['status'] is "failed":
-            name = msg['msg']['image_name']
-            dest = msg['msg']['destination']
-            tmpl = self._('Image {image_name} failed to upload to {dest}')
-            return tmpl.format(image_name=name, dest=dest)
+        if 'image.upload' in msg['topic']:
+            if msg['msg']['status'] is "started":
+                name = msg['msg']['image_name']
+                dest = msg['msg']['destination']
+                tmpl = self._('Image {image_name} started uploading to {dest}')
+                return tmpl.format(image_name=name, dest=dest)
+            elif msg['msg']['status'] is "completed":
+                name = msg['msg']['image_name']
+                dest = msg['msg']['destination']
+                tmpl = self._('Image {image_name} finished uploading to to {dest}')
+                return tmpl.format(image_name=name, dest=dest)
+            elif msg['msg']['status'] is "failed":
+                name = msg['msg']['image_name']
+                dest = msg['msg']['destination']
+                tmpl = self._('Image {image_name} failed to upload to {dest}')
+                return tmpl.format(image_name=name, dest=dest)
+        if 'image.test' in msg['topic']:
+            if msg['msg']['status'] is "started":
+                name = msg['msg']['image_name']
+                dest = msg['msg']['destination']
+                tmpl = self._('Image {image_name} started testing on {dest}')
+                return tmpl.format(image_name=name, dest=dest)
+            elif msg['msg']['status'] is "completed":
+                name = msg['msg']['image_name']
+                dest = msg['msg']['destination']
+                tmpl = self._('Image {image_name} finished testing on {dest}')
+                return tmpl.format(image_name=name, dest=dest)
+            elif msg['msg']['status'] is "failed":
+                name = msg['msg']['image_name']
+                dest = msg['msg']['destination']
+                tmpl = self._('Image {image_name} failed testing on {dest}')
+                return tmpl.format(image_name=name, dest=dest)

--- a/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
@@ -56,6 +56,37 @@ class TestImageUpload(Base):
         u'timestamp': 1371498303.125771,
     }
 
+
+class TestImageTest(Base):
+    """ These messages are awarded when an image starts has started,
+    completes, or fails. """
+
+    expected_title = "fedimg.image.test"
+    image_name = "fedora-cloud-base-rawhide-20140604.x86_64"
+    dest = "EC2-eu-west-1"
+    expected_subti = "Image {0} started testing on {1}".format(image_name,
+                                                                 dest)
+    expected_link = None
+    expected_icon = None
+    expected_secondary_icon = None
+    expected_packages = set([])
+    expected_usernames = set([])
+    expected_objects = set([])
+    msg = {
+        u'i': 1,
+        u'msg': {
+            u'image_url': 'https://kojipkgs.fedoraproject.org//work/'
+                          'tasks/5144/6925144/fedora-cloud-base-'
+                          'rawhide-20140604.x86_64.raw.xz',
+            u'image_name': 'fedora-cloud-base-rawhide-20140604.x86_64',
+            u'destination': 'EC2-eu-west-1',
+            u'status': 'started',
+        },
+        u'topic': u'org.fedoraproject.stg.fedimg.image.test',
+        u'username': u'fedimg',
+        u'timestamp': 1371498303.125771,
+    }
+
 add_doc(locals())
 
 if __name__ == '__main__':


### PR DESCRIPTION
The new `fedimg.image.test` topic reports in when tests on a newly-generated AMI start, complete, or fail. Includes tests.
