### PR TITLE
Hide old pkgdb1 retirement messages from the docs.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/pkgdb.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pkgdb.py
@@ -359,7 +359,7 @@ class TestPkgdbCritpathUpdate(Base):
     }
 
 
-class TestPkgdbPackageRetire(Base):
+class TestLegacyPkgdbPackageRetire(Base):
     """ The Fedora `Package DB <https://admin.fedoraproject.org/pkgdb>`_
     publishes messages on this topic when a package is retired.  For example:
     """


### PR DESCRIPTION
Things that have 'Legacy' in the test name don't show up in the docs.

These messages are examples from the old pkgdb1.  We want to keep the
tests around for old messages held in datagrepper, but we don't want to
advertise them to users in the docs.
