### PR TITLE
Mark these pkgdb examples as Legacy

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/pkgdb.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pkgdb.py
@@ -1241,7 +1241,7 @@ class TestPkgdbDeleteAcl(Base):
     }
 
 
-class LegacyTestPkgdbBranchRequest(Base):
+class TestPkgdbBranchRequest(Base):
     """ The Fedora `Package DB <https://admin.fedoraproject.org/pkgdb>`_
     publishes messages like these when an user **requests a new branch** for
     a particular package.
@@ -1295,7 +1295,7 @@ class LegacyTestPkgdbBranchRequest(Base):
     }
 
 
-class LegacyTestPkgdbPackageRequest(Base):
+class TestPkgdbPackageRequest(Base):
     """ The Fedora `Package DB <https://admin.fedoraproject.org/pkgdb>`_
     publishes messages like these when an user **requests a new package**
     to be added into Package DB.


### PR DESCRIPTION
This needs scrutiny from @pypingou and @tyll.

By marking these tests as `Legacy`, they will no longer show up in the
docs at http://fedora-fedmsg.readthedocs.org/en/latest/topics.html

In fedora-infra/fedmsg#255, @tyll mentioned that some pkgdb1 messages
still appeared in the docs even though they are not being broadcast
anymore.  I did my best to check that the topics of these messages that
I've marked do not actually appear in the pkgdb2 source, but I'd be much
more comfortable merging this if someone more familiar with the source
could look over them.

If merged, this fixes fedora-infra/fedmsg#255.
