### PR TITLE
Return the full patch for scm long_form.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.rst
 recursive-include fedmsg.d *.py
+include fedmsg_meta_fedora_infrastructure/tests/example.patch

--- a/fedmsg_meta_fedora_infrastructure/tests/example.patch
+++ b/fedmsg_meta_fedora_infrastructure/tests/example.patch
@@ -1,0 +1,43 @@
+From 66abdea4014eb2f0745fc38f86e20c7d7009237e Mon Sep 17 00:00:00 2001
+From: Ralph Bean <rbean@redhat.com>
+Date: Mon, 8 Oct 2012 13:25:49 -0400
+Subject: Try removing requirement on python-bunch.
+
+
+diff --git a/datanommer.spec b/datanommer.spec
+index c34b795..1db1d0a 100644
+--- a/datanommer.spec
++++ b/datanommer.spec
+@@ -1,6 +1,6 @@
+ Name:             datanommer
+ Version:          0.1.8
+-Release:          1%{?dist}
++Release:          2%{?dist}
+ Summary:          A storage consumer for the Fedora Message Bus (fedmsg)
+ 
+ Group:            Development/Libraries
+@@ -28,11 +28,6 @@ BuildRequires:    python-sqlalchemy >= 0.7
+ Requires:         python-sqlalchemy >= 0.7
+ %endif
+ 
+-# This is required due to a bug in moksha's packaging
+-# That is fixed in moksha-0.8.8-4
+-BuildRequires:    python-bunch
+-Requires:         python-bunch
+-
+ 
+ %description
+ This is datanommer.  It is comprised of only a `fedmsg
+@@ -73,6 +68,9 @@ database.
+ %{_bindir}/datanommer-dump
+ 
+ %changelog
++* Mon Oct 08 2012 Ralph Bean <rbean@redhat.com> - 0.1.8-2
++- Remove requirement on python-bunch.
++
+ * Thu Oct 04 2012 Ralph Bean <rbean@redhat.com> - 0.1.8-1
+ - More flexible database field types.
+ * Fri Sep 28 2012 Ralph Bean <rbean@redhat.com> - 0.1.7-1
+-- 
+cgit v0.10.1
+

--- a/fedmsg_meta_fedora_infrastructure/tests/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/scm.py
@@ -1,5 +1,5 @@
 # This file is part of fedmsg.
-# Copyright (C) 2012 Red Hat, Inc.
+# Copyright (C) 2012-2014 Red Hat, Inc.
 #
 # fedmsg is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -16,14 +16,21 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 # Authors:  Ian Weller <ianweller@fedoraproject.org>
+#           Ralph Bean <rbean@redhat.com>
 #
 """ Tests for git messages """
 
+import os
 import unittest
 
 from fedmsg.tests.test_meta import Base
 
 from common import add_doc
+
+
+here = os.path.dirname(__file__)
+with open(here + '/example.patch', 'r') as f:
+    full_patch = f.read()
 
 
 class TestGitReceiveOldModified(Base):
@@ -34,6 +41,7 @@ class TestGitReceiveOldModified(Base):
     expected_title = "git.receive"
     expected_subti = ('rbean@redhat.com pushed to datanommer (master).  "Try '
                       'removing requirement on python-bunch."')
+    expected_long_form = expected_subti + "\n\n" + full_patch
     expected_secondary_icon = (
         'https://seccdn.libravatar.org/avatar/'
         '1a0d2acfddb1911ecf55da42cfa34710'


### PR DESCRIPTION
This builds off of the patch in fedora-infra/fedmsg#287 and is
ultimately to be used by FMN as discussed in fedora-infra/fmn#26.
