### PR TITLE
Add groups field to koschei.package.state.change

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/koschei.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/koschei.py
@@ -51,6 +51,7 @@ class TestKoscheiPackageStateChange(Base):
             "old": "ok",
             "new": "failing",
             "koji_instance": "arm",
-            "repo": "f22"
+            "repo": "f22",
+            "groups": ["c", "xml"]
         }
     }


### PR DESCRIPTION
The field will be useful for filtering in FMN, I forgot to add it in the previous request. Processor doesn't use it, documentation-only change.
