### PR TITLE
lookaside: Dehardcode some assumptions

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/scm.py
@@ -146,12 +146,21 @@ class SCMProcessor(BaseProcessor):
             return tmpl.format(prefix=prefix, repo=repo, branch=branch)
         elif '.git.lookaside' in msg['topic']:
             prefix = "http://pkgs.fedoraproject.org/lookaside/pkgs"
-            name = msg['msg']['name']
-            md5sum = msg['msg']['md5sum']
-            filename = msg['msg']['filename']
-            tmpl = "{prefix}/{name}/{filename}/{md5sum}/{filename}"
-            return tmpl.format(prefix=prefix, name=name,
-                               md5sum=md5sum, filename=filename)
+
+            if 'path' in msg['msg']:
+                path = msg['msg']['path']
+
+            else:
+                # Fallback to the old message format from the dark ages of MD5
+                name = msg['msg']['name']
+                md5sum = msg['msg']['md5sum']
+                filename = msg['msg']['filename']
+                tmpl = "{name}/{filename}/{md5sum}/{filename}"
+
+                path = tmpl.format(name=name, md5sum=md5sum,
+                                   filename=filename)
+
+            return "{prefix}/{path}".format(prefix=prefix, path=path)
 
     def usernames(self, msg, **config):
         if 'agent' in msg['msg']:

--- a/fedmsg_meta_fedora_infrastructure/summershum.py
+++ b/fedmsg_meta_fedora_infrastructure/summershum.py
@@ -66,9 +66,17 @@ class SummerShumProcessor(BaseProcessor):
     def link(self, msg, **config):
         o = msg['msg']['original']
         prefix = "http://pkgs.fedoraproject.org/lookaside/pkgs"
-        name = o['name']
-        md5sum = o['md5sum']
-        filename = o['filename']
-        tmpl = "{prefix}/{name}/{filename}/{md5sum}/{filename}"
-        return tmpl.format(prefix=prefix, name=name,
-                           md5sum=md5sum, filename=filename)
+
+        if 'path' in o:
+            path = o['path']
+
+        else:
+            # Fallback to the old message format from the dark ages of MD5
+            name = o['name']
+            md5sum = o['md5sum']
+            filename = o['filename']
+            tmpl = "{name}/{filename}/{md5sum}/{filename}"
+
+            path = tmpl.format(name=name, md5sum=md5sum, filename=filename)
+
+        return "{prefix}/{path}".format(prefix=prefix, path=path)


### PR DESCRIPTION
The current code assumes that:
1. the message contains a 'md5sum' key, which is going to go away when
   we move to a different hash algorithm,
2. it knows the path to the file on the lookaside cache, which is going
   to change very soon.

The solution this change implements is to simply take the path to the
uploaded source file entirely from the message.

However, the lookaside cache doesn't emit messages like this yet, so the
current code is kept as a fallback.

https://fedorahosted.org/rel-eng/ticket/5846
