### PR TITLE
Fix test failures for conglomerator ordering.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/conglomerate/bodhi/test_comments.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/conglomerate/bodhi/test_comments.py
@@ -156,8 +156,8 @@ class TestBodhiConglomerateCommentSameUser(
         },
     ]
     expected = [{
-        'subtitle': 'hreindl commented on sqlite-3.8.6-2.fc20 '
-        'and file-5.19-4.fc20',
+        'subtitle': 'hreindl commented on file-5.19-4.fc20 '
+        'and sqlite-3.8.6-2.fc20',
         'link': 'https://admin.fedoraproject.org/updates/user/hreindl/',
         'icon': 'https://admin.fedoraproject.org/updates/'
         'static/images/bodhi-icon-48.png',

--- a/fedmsg_meta_fedora_infrastructure/tests/conglomerate/bodhi/test_requests.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/conglomerate/bodhi/test_requests.py
@@ -155,7 +155,7 @@ class TestBodhiConglomerateTestingSamePackageSameUser(
     ]
     expected = [{
         'subtitle': 'pghmcfc submitted 2 perl-Devel-CheckBin '
-        'testing updates for F19 and F20',
+        'testing updates for F20 and F19',
         'link': 'https://admin.fedoraproject.org/updates/perl-Devel-CheckBin/',
         'icon': 'https://admin.fedoraproject.org/updates/'
         'static/images/bodhi-icon-48.png',
@@ -331,7 +331,7 @@ class TestBodhiConglomerateTestingSamePackageDifferentUser(
     ]
     expected = [{
         'subtitle': 'ralph and pghmcfc submitted 2 perl-Devel-CheckBin '
-        'updates for F19 and F20',
+        'updates for F20 and F19',
         'link': 'https://admin.fedoraproject.org/updates/perl-Devel-CheckBin/',
         'icon': 'https://admin.fedoraproject.org/updates/'
         'static/images/bodhi-icon-48.png',
@@ -506,7 +506,7 @@ class TestBodhiConglomerateTestingSameUserDifferentPackage(
     ]
     expected = [{
         'subtitle': 'pghmcfc submitted nethack and perl-Devel-CheckBin '
-        'updates for F19 and F20',
+        'updates for F20 and F19',
         'link': 'https://admin.fedoraproject.org/updates/user/pghmcfc/',
         'icon': 'https://admin.fedoraproject.org/updates/'
         'static/images/bodhi-icon-48.png',


### PR DESCRIPTION
These were triggered by changes in fedora-infra/fedmsg#150.
