### PR TITLE
No longer stuff package owners in msg2usernames for pkgdb.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/pkgdb.py
+++ b/fedmsg_meta_fedora_infrastructure/pkgdb.py
@@ -354,16 +354,6 @@ class PkgdbProcessor(BaseProcessor):
             pass
 
         try:
-            users.add(msg['msg']['package_listing']['point_of_contact'])
-        except KeyError:
-            pass
-
-        try:
-            users.add(msg['msg']['package_listing']['owner'])
-        except KeyError:
-            pass
-
-        try:
             users.add(msg['msg']['acl']['fas_name'])
         except (KeyError, TypeError):
             pass

--- a/fedmsg_meta_fedora_infrastructure/tests/pkgdb.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pkgdb.py
@@ -366,7 +366,7 @@ class LegacyTestPkgdbBranchClone(Base):
     }
 
 
-class TestPkgdbCritpathUpdate(Base):
+class TestLegacyPkgdbCritpathUpdate(Base):
     """ The Fedora `Package DB <https://admin.fedoraproject.org/pkgdb>`_
     publishes messages on this topic when the critical path status of a
     package changes (when it is either added, or removed from the critical

--- a/fedmsg_meta_fedora_infrastructure/tests/pkgdb.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pkgdb.py
@@ -41,7 +41,7 @@ class TestPkgdbACLUpdate(Base):
         "https://seccdn.libravatar.org/avatar/"
         "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c?s=64&d=retro")
     expected_packages = set(['python-sh'])
-    expected_usernames = set(['ralph', 'grover'])
+    expected_usernames = set(['ralph'])
     expected_objects = set(['python-sh/acls/EL-6/watchbugzilla/ralph'])
     msg = {
         "username": "apache",
@@ -94,7 +94,7 @@ class TestPkgdbPackageNew(Base):
         "https://seccdn.libravatar.org/avatar/"
         "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c?s=64&d=retro")
     expected_packages = set(['php-zmq'])
-    expected_usernames = set(['ralph', 'lmacken'])
+    expected_usernames = set(['ralph'])
     expected_objects = set(['php-zmq/create'])
     msg = {
         "username": "apache",
@@ -263,7 +263,7 @@ class TestPkgdbPackageUpdateStatus(Base):
         "https://seccdn.libravatar.org/avatar/"
         "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c?s=64&d=retro")
     expected_packages = set(['guake'])
-    expected_usernames = set(['ralph', 'pingou'])
+    expected_usernames = set(['ralph'])
     expected_objects = set(['guake/update'])
     msg = {
         "username": "apache",
@@ -1178,7 +1178,7 @@ class TestPkgdbDeleteBranch(Base):
         "a89b57d99dcf12d40ec2b9fb05910b90293b13b0b87415208bedc897bc18a354"
         "?s=64&d=retro")
     expected_packages = set(['pipelight'])
-    expected_usernames = set(['ausil', 'besser82'])
+    expected_usernames = set(['ausil'])
     expected_objects = set(['pipelight/f21/delete'])
     msg = {
         "i": 45,


### PR DESCRIPTION
It used to be that, for pkgdb messages, msg2usernames included many
usernames:  the actor performing the event, the subject on whom the action
was performed, and any package owners of the package.

That third bit was added as a hack to get message routing in FMN working
easily when it first launched.  I wanted to route pkgdb messages to package
owners when requests were made on their packages.

This is no longer necessary since FMN can now query pkgdb for who owns what
packages.. but furthermore it actually breaks other more complicated
filters that we're adding to the default set.

For instance, there is a rule that says "if someone does something to one
of my packages, tell me unless I did it".  The "unless I did it" part is
artificially evaluating to true, since everyone's usernames get returned by
msg2usernames.  This commit should fix that.