### PR TITLE
Demote this error message.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/fasshim.py
+++ b/fedmsg_meta_fedora_infrastructure/fasshim.py
@@ -95,7 +95,7 @@ def make_fas_cache(**config):
                                          req_params={'search': '*'},
                                          auth=True)
     except fedora.client.ServerError as e:
-        log.error("Failed to download fas cache %r" % e)
+        log.warning("Failed to download fas cache %r" % e)
         return {}
     finally:
         socket.setdefaulttimeout(timeout)


### PR DESCRIPTION
We get emails every time log.error is called.  The problem with this one
is that it happens quite often, and it's not really actionable.  There's
nothing for us to do about it.  Better to reduce email noise so we can
actually respond to other errors that are more significant.