### PR TITLE
Convert github.watch messages to github.star.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/github.py
+++ b/fedmsg_meta_fedora_infrastructure/github.py
@@ -63,6 +63,8 @@ class GithubProcessor(BaseProcessor):
     def link(self, msg, **config):
         if 'github.watch' in msg['topic']:
             return msg['msg']['repository']['html_url'] + "/watchers"
+        if 'github.star' in msg['topic']:
+            return msg['msg']['repository']['html_url'] + "/stargazers"
         if 'release' in msg['msg']:
             return msg['msg']['release']['html_url']
         if 'target_url' in msg['msg']:
@@ -155,6 +157,14 @@ class GithubProcessor(BaseProcessor):
             tmpl = self._('{user} {action} watching {repo}')
             action = msg['msg']['action']
             return tmpl.format(user=user, repo=repo, action=action)
+        elif 'github.star' in msg['topic']:
+            tmpl = self._('{user} {action} {repo}')
+            action = msg['msg']['action']
+            if action == 'started':
+                action = 'starred'
+            else:
+                action = 'unstarred'
+            return tmpl.format(user=user, repo=repo, action=action)
         elif 'github.release' in msg['topic']:
             tmpl = self._('{user} cut a release of {repo}, version {version}')
             version = msg['msg']['release']['tag_name']
@@ -187,6 +197,7 @@ class GithubProcessor(BaseProcessor):
             'github.create': None,
             'github.delete': None,
             'github.watch': None,
+            'github.star': None,
         }
 
         if suffix not in lookup:
@@ -223,5 +234,7 @@ class GithubProcessor(BaseProcessor):
             items = [msg['msg']['release']['tag_name']]
         elif suffix == 'github.watch':
             items = ['watchers']
+        elif suffix == 'github.star':
+            items = ['stargazers']
 
         return set([base + '/' + item for item in items])

--- a/fedmsg_meta_fedora_infrastructure/tests/github.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/github.py
@@ -1524,14 +1524,8 @@ class TestGithubCommitComment(Base):
     }
 
 
-class TestGithubWatch(Base):
-    """ There exists `a service
-    <https://apps.fedoraproject.org/github2fedmsg>`_ to link the select github
-    repos of fedora contributors with the fedmsg bus.
-
-    Messages of *this* type are published whenever someone **watches a
-    repository**.
-    """
+class TestGithubLegacyWatch(Base):
+    """ Old github.watch messages.  These no longer exist. """
 
     expected_title = "github.watch"
     expected_subti = "alikins started watching fedora-infra/summershum"
@@ -1552,6 +1546,88 @@ class TestGithubWatch(Base):
         "timestamp": 1403363334.0,
         "msg_id": "2014-5273bf43-d483-48d4-a8d6-11c988cae0cb",
         "topic": "org.fedoraproject.prod.github.watch",
+        "source_version": "0.6.4",
+        "msg": {
+            "action": "started",
+            "fas_usernames": {},
+            "repository": {
+                "has_wiki": False,
+                "forks_count": 7,
+                "updated_at": "2014-06-21T15:08:53Z",
+                "private": False,
+                "full_name": "fedora-infra/summershum",
+                "owner": {
+                    "url": "https://api.github.com/users/fedora-infra",
+                    "site_admin": False,
+                    "html_url": "https://github.com/fedora-infra",
+                    "gravatar_id": "ebdef1eaaa4b1c1cb01f5570efbb3cc4",
+                    "login": "fedora-infra",
+                    "type": "Organization",
+                    "id": 3316637
+                },
+                "id": 16620564,
+                "size": 907,
+                "watchers_count": 10,
+                "forks": 7,
+                "homepage": "",
+                "fork": False,
+                "description": "fedmsg consumer that extracts hashes of "
+                "source files",
+                "has_downloads": True,
+                "default_branch": "develop",
+                "html_url": "https://github.com/fedora-infra/summershum",
+                "has_issues": True,
+                "stargazers_count": 10,
+                "open_issues_count": 2,
+                "watchers": 10,
+                "name": "summershum",
+                "language": "Python",
+                "url": "https://api.github.com/repos/fedora-infra/summershum",
+                "created_at": "2014-02-07T16:35:59Z",
+                "pushed_at": "2014-06-13T12:11:18Z",
+                "open_issues": 2
+            },
+            "sender": {
+                "url": "https://api.github.com/users/alikins",
+                "site_admin": False,
+                "html_url": "https://github.com/alikins",
+                "gravatar_id": "81877b32b5fac41db3207c94ecc26173",
+                "login": "alikins",
+                "type": "User",
+                "id": 15162
+            }
+        }
+    }
+
+
+class TestGithubStar(Base):
+    """ There exists `a service
+    <https://apps.fedoraproject.org/github2fedmsg>`_ to link the select github
+    repos of fedora contributors with the fedmsg bus.
+
+    Messages of *this* type are published whenever someone **stars a
+    repository**.
+    """
+
+    expected_title = "github.star"
+    expected_subti = "alikins starred fedora-infra/summershum"
+    expected_link = "https://github.com/fedora-infra/summershum/stargazers"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/github.png"
+    expected_secondary_icon = (
+        "https://seccdn.libravatar.org/avatar/"
+        "d23ffcf6c375ae6351f54b6d4e381c6910e68d666370e5ff21e4322cd56690bf"
+        "?s=64&d=retro")
+    expected_packages = set([])
+    expected_usernames = set([])
+    expected_objects = set([
+        'fedora-infra/summershum/stargazers',
+    ])
+    msg = {
+        "source_name": "datanommer",
+        "i": 1,
+        "timestamp": 1403363334.0,
+        "msg_id": "2014-5273bf43-d483-48d4-a8d6-11c988cae0cb",
+        "topic": "org.fedoraproject.prod.github.star",
         "source_version": "0.6.4",
         "msg": {
             "action": "started",


### PR DESCRIPTION
It turns out that github's event system is weird and their
``X-Github-Event: watch`` header actually means that someone starred a
repository.

This updates us to make more sense in our links and text.

An update to github2fedmsg that converts the messages will be coming
soon.