### PR TITLE
(anitya) Substitute Fedora package name for project name if available.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/anitya.py
+++ b/fedmsg_meta_fedora_infrastructure/anitya.py
@@ -128,7 +128,7 @@ class AnityaProcessor(BaseProcessor):
             # substitute "our" package name for the project name to make
             # everyone's emails more readable.
             # https://github.com/fedora-infra/the-new-hotness/issues/21
-            for package in message['packages']:
+            for package in message.get('packages', []):
                 if package['distro'] == 'Fedora':
                     project = package['package_name']
 

--- a/fedmsg_meta_fedora_infrastructure/anitya.py
+++ b/fedmsg_meta_fedora_infrastructure/anitya.py
@@ -118,10 +118,20 @@ class AnityaProcessor(BaseProcessor):
             return tmpl.format(user=user, project=project, distro=distro)
         elif 'project.version.update' in msg['topic']:
             project = msg['msg']['project']['name']
+
             if 'message' in msg['msg']:
                 message = msg['msg']['message']
             else:
                 message = msg['msg']
+
+            # If this project is mapped to a Fedora package, then just
+            # substitute "our" package name for the project name to make
+            # everyone's emails more readable.
+            # https://github.com/fedora-infra/the-new-hotness/issues/21
+            for package in message['packages']:
+                if package['distro'] == 'Fedora':
+                    project = package['package_name']
+
             old = message['old_version']
             new = message['upstream_version']
             tmpl = self._(

--- a/fedmsg_meta_fedora_infrastructure/tests/anitya.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/anitya.py
@@ -394,7 +394,7 @@ class TestUpdatedMappingProject(Base):
 
 class TestFirstNewUpstreamVersionLegacy(Base):
     expected_title = "anitya.project.version.update"
-    expected_subti = 'A new version of "Accanthis-Std" has been ' + \
+    expected_subti = 'A new version of "adf-accanthis-fonts" has been ' + \
         'detected:  "20101124"'
     expected_link = "https://release-monitoring.org/project/22/"
     expected_icon = "https://apps.fedoraproject.org/packages/" + \


### PR DESCRIPTION
This should fix fedora-infra/the-new-hotness#21.