### PR TITLE
Don't return prematurely if parent task is still open.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/buildsys.py
@@ -73,7 +73,7 @@ class KojiProcessor(BaseProcessor):
             result = sess.getTaskResult(taskid)
         except Exception as e:
             log.warning(unicode(e))
-            return retval + "\n" + unicode(e) + "\n"
+            retval += "\n" + unicode(e) + "\n"
 
         if result:
             for kind in ['logs', 'rpms', 'srpms']:
@@ -89,6 +89,7 @@ class KojiProcessor(BaseProcessor):
         children = sess.getTaskChildren(taskid)
         for child in sorted(children, key=lambda d: d['completion_ts']):
             retval += "\n" + cls._fill_task_template(sess, child['id'])
+
         return retval
 
     @classmethod


### PR DESCRIPTION
@robert-scheck hit this here:
https://github.com/fedora-infra/fmn/issues/54#issuecomment-76531828


- There is a parent build which had one task:
   - That task had three child tasks
        - srpmfromscm
        - buildarch
        - tagbuild

All three grandchild tasks were done and koji published a fedmsg message
about it, but the middle-parent task had not yet become 'closed'.  FMN
tried to get the 'results' of the middle-parent task, but when that task
is still 'open', this throws an exception.

We can handle that exception, but we returned prematurely from the
``_fill_task_template`` method, returning before we had a chance to
iterate over the grandchild tasks that have the most interesting
information (binary rpms, logs, etc).

This patch should avoid that premature return so we can cram as much
info as is available in our emails.