### PR TITLE
Added message handler and tests for Github member 

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/github.py
+++ b/fedmsg_meta_fedora_infrastructure/github.py
@@ -180,6 +180,13 @@ class GithubProcessor(BaseProcessor):
             tmpl = self._("The '{team_name}' team was added to the {repo} repository")
             teamName = msg['msg']['team']['slug']
             return tmpl.format(team_name=teamName,repo=repo)
+        elif 'github.member' in msg['topic']:
+            if msg['msg']['action'] == 'added':
+                tmpl = self._("{user} added {member} as a member of {repo}")
+            else:
+                tmpl = self._("{user} removed member {member} from {repo}")
+            member = msg['msg']['member']['login']
+            return tmpl.format(user=user,member=member,repo=repo)
         else:
             pass
 
@@ -209,7 +216,8 @@ class GithubProcessor(BaseProcessor):
             'github.watch': None,
             'github.star': None,
             'github.page_build': 'page_build',
-            'github.team_add': 'team_add'
+            'github.team_add': 'team_add',
+            'github.member': 'member'
         }
 
         if suffix not in lookup:

--- a/fedmsg_meta_fedora_infrastructure/tests/github.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/github.py
@@ -2032,6 +2032,97 @@ class TestGithubTeamAdd(Base):
       }
     }
 
+class TestGithubMember(Base):
+    """ There exists `a service
+    <https://apps.fedoraproject.org/github2fedmsg>`_ to link the select github
+    repos of fedora contributors with the fedmsg bus.
+
+    Messages of *this* type are published whenever someone **Adds a team to Github Repository**.
+    """
+    expected_title = "github.member"
+    expected_subti = "ralph added decause as a member of ralphbean/lightsaber"
+    expected_link = "https://github.com/ralphbean/lightsaber"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/github.png"
+    expected_secondary_icon = (
+        "https://seccdn.libravatar.org/avatar/"
+        "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
+        "?s=64&d=retro")
+    expected_packages = set([])
+    expected_usernames = set(['ralph'])
+    expected_objects = set(['ralphbean/lightsaber/member'])
+    msg = {  
+        "source_name": "datanommer",
+        "i": 2, 
+        "timestamp": 1426257201.0, 
+        "msg_id": "2015-b21fdc03-9f22-4d6f-a086-74d4dae25b6c", 
+        "topic": "org.fedoraproject.prod.github.member", 
+        "source_version": "0.6.4", 
+        "msg": {
+            "action": "added", 
+            "member": {
+              "url": "https://api.github.com/users/decause", 
+              "site_admin": False, 
+              "html_url": "https://github.com/decause", 
+              "gravatar_id": "", 
+              "login": "decause", 
+              "type": "User", 
+              "id": 427420
+            }, 
+            "fas_usernames": {
+              "ralphbean": "ralph"
+            }, 
+            "repository": {
+              "has_wiki": False, 
+              "has_pages": False, 
+              "updated_at": "2015-03-13T13:23:31Z", 
+              "private": False, 
+              "full_name": "ralphbean/lightsaber", 
+              "owner": {
+                "url": "https://api.github.com/users/ralphbean", 
+                "site_admin": False, 
+                "html_url": "https://github.com/ralphbean", 
+                "gravatar_id": "", 
+                "login": "ralphbean", 
+                "type": "User", 
+                "id": 331338
+              }, 
+              "id": 13132894, 
+              "size": 1397, 
+              "watchers_count": 15, 
+              "forks": 3, 
+              "homepage": "", 
+              "fork": False, 
+              "description": "Everyone has to build their own...", 
+              "has_downloads": True, 
+              "forks_count": 3, 
+              "default_branch": "develop", 
+              "html_url": "https://github.com/ralphbean/lightsaber", 
+              "has_issues": True, 
+              "stargazers_count": 15, 
+              "open_issues_count": 1, 
+              "watchers": 15, 
+              "name": "lightsaber", 
+              "language": "Python", 
+              "url": "https://api.github.com/repos/ralphbean/lightsaber", 
+              "created_at": "2013-09-26T20:00:13Z", 
+              "pushed_at": "2015-03-13T13:23:31Z", 
+              "open_issues": 1
+            }, 
+            "sender": {
+              "url": "https://api.github.com/users/ralphbean", 
+              "site_admin": False, 
+              "html_url": "https://github.com/ralphbean", 
+              "gravatar_id": "", 
+              "login": "ralphbean", 
+              "type": "User", 
+              "id": 331338
+            }
+        }
+    }
+
+
+
+
 if not 'FEDMSG_META_NO_NETWORK' in os.environ:
     TestGithubPush.expected_long_form = \
         TestGithubPush.expected_subti + "\n\n" + full_patch1


### PR DESCRIPTION
@ralphbean , The example message was mainly for member added to github repo. The added/removed action is mentioned `msg['msg']['action']`. Currently it will handle a `member removed` message also and give a message as `ralph removed member decause from ralphbean/lightsaber`
