### PR TITLE
Shorten git commit emails if they have already been seen.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/scm.py
@@ -23,6 +23,9 @@ from fasshim import gravatar_url, gravatar_url_from_email
 import requests
 
 
+already_seen_msg = "This commit already existed in another branch."
+
+
 class SCMProcessor(BaseProcessor):
     __name__ = "git"
     __description__ = "the Fedora version control system"
@@ -53,6 +56,11 @@ class SCMProcessor(BaseProcessor):
                 repo = '.'.join(msg['topic'].split('.')[5:-1])
 
             rev = msg['msg']['commit']['rev']
+
+            seen = msg['msg']['commit'].get('seen', False)
+            if seen:
+                return self.subtitle(msg, **config) + '\n\n' + already_seen_msg
+
             url = 'http://pkgs.fedoraproject.org/cgit/' + \
                 '{repo}.git/patch/?id={rev}'
             response = requests.get(url.format(repo=repo, rev=rev))

--- a/fedmsg_meta_fedora_infrastructure/tests/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/scm.py
@@ -196,6 +196,8 @@ class TestSCM(Base):
     expected_link = "http://pkgs.fedoraproject.org/cgit/" + \
         "valgrind.git/commit/" + \
         "?h=master&id=7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1"
+    expected_long_form = expected_subti + "\n\n" + \
+        "This commit already existed in another branch."
     expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
     expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
         "0f32874b1ae3083205c874c83cd2d21715c89b8645483f353e90ae499c67c944"
@@ -210,6 +212,7 @@ class TestSCM(Base):
         "topic": "org.fedoraproject.prod.git.receive",
         "msg": {
             "commit": {
+                "seen": True,
                 "stats": {
                     "files": {
                         "valgrind.spec": {


### PR DESCRIPTION
This draws on the new message content introduced in fedora-infra/fedmsg#327.