### PR TITLE
Strip out None values from the bodhi usernames list.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/bodhi.py
+++ b/fedmsg_meta_fedora_infrastructure/bodhi.py
@@ -322,6 +322,10 @@ class BodhiProcessor(BaseProcessor):
         if 'agent' in msg['msg']:
             users.append(msg['msg']['agent'])
 
+        # Strip out None values.  In some cases, we're getting None values
+        # here.. I think from the 'agent' field of an anonymous bodhi comment.
+        users = [u for u in users if u is not None]
+
         return set(users)
 
     def objects(self, msg, **config):


### PR DESCRIPTION
In some cases, we're getting None values
here.. I think from the 'agent' field of an anonymous bodhi comment.