### PR TITLE
Add long_form for koji scratch builds.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/buildsys.py
@@ -147,6 +147,15 @@ class KojiProcessor(BaseProcessor):
             build = msg['msg']
             long_form = self._fill_build_template(session, build)
             return self.subtitle(msg, **config) + "\n\n" + long_form
+        if 'buildsys.task.state.change' in msg['topic'] and koji:
+            session = koji.ClientSession(url)
+            taskid = msg['msg']['id']
+            try:
+                long_form = self._fill_task_template(session, taskid)
+            except Exception as e:
+                log.warning(unicode(e))
+                long_form = unicode(e)
+            return self.subtitle(msg, **config) + "\n\n" + long_form
 
     def subtitle(self, msg, **config):
         inst = msg['msg'].get('instance', 'primary')

--- a/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
@@ -114,6 +114,19 @@ Task Type: tagBuild (noarch)
 Link: https://koji.fedoraproject.org/koji/taskinfo?taskID=8973199
 """
 
+_scratch_long_form_fail = """Task 6380373 on arm02-builder22.arm.fedoraproject.org
+Task Type: build (noarch)
+Link: https://koji.fedoraproject.org/koji/taskinfo?taskID=6380373
+
+error building package (arch noarch), mock exited with status 1; see build.log for more information
+
+Task 6380374 on buildvm-17.phx2.fedoraproject.org
+Task Type: buildArch (noarch)
+Link: https://koji.fedoraproject.org/koji/taskinfo?taskID=6380374
+
+error building package (arch noarch), mock exited with status 1; see build.log for more information
+"""
+
 
 class TestKojiTaskStateChangeStart(Base):
     """ Koji emits messages on this topic anytime the state of a **scratch**
@@ -577,7 +590,9 @@ if koji and not (
     #TestKojiBuildStateChangeCancel.expected_long_form = \
     #    TestKojiBuildStateChangeCancel.expected_subti + "\n\n" + \
     #    _build_long_form_cancel
-
+    TestKojiTaskStateChangeFail.expected_long_form = \
+        TestKojiTaskStateChangeFail.expected_subti + "\n\n" + \
+        _scratch_long_form_fail
 
 class TestKojiRepoInit(Base):
     """ Koji emits these messages when a repository begins initializing. """

--- a/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
@@ -49,28 +49,28 @@ _build_long_form_fail = """Package:    64tass-1.51.727-1.fc22
 Status:     failed
 Built by:   sharkcz
 ID:         288888
-Started:    Tue, 24 Feb 2015 14:19:09 UTC
-Finished:   Tue, 24 Feb 2015 14:19:46 UTC
+Started:    Sat, 14 Mar 2015 19:09:10 UTC
+Finished:   Sat, 14 Mar 2015 19:11:02 UTC
 
 Closed tasks:
 -------------
-Task 1739950 on fedora1.s390.bos.redhat.com
+Task 1755171 on fedora3.s390.bos.redhat.com
 Task Type: build (noarch)
-Link: http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=1739950
+Link: http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=1755171
 
-could not init mock buildroot, mock exited with status 1; see build.log for more information
+error building package (arch s390), mock exited with status 1; see build.log for more information
 
-Task 1739951 on fedora3.s390.bos.redhat.com
+Task 1755172 on fedora3.s390.bos.redhat.com
 Task Type: buildArch (s390)
-Link: http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=1739951
+Link: http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=1755172
 
-could not init mock buildroot, mock exited with status 1; see build.log for more information
+error building package (arch s390), mock exited with status 1; see build.log for more information
 
-Task 1739952 on fedora6.s390.bos.redhat.com
+Task 1755173 on fedora2.s390.bos.redhat.com
 Task Type: buildArch (s390x)
-Link: http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=1739952
+Link: http://s390.koji.fedoraproject.org/koji/taskinfo?taskID=1755173
 
-could not init mock buildroot, mock exited with status 1; see build.log for more information
+error building package (arch s390x), mock exited with status 1; see build.log for more information
 """
 
 


### PR DESCRIPTION
We already do this for real builds.  Might as well add details for scratch
builds.

Fixes fedora-infra/fmn#74.