### PR TITLE
De-duplicate subtitles from long_form representations.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/buildsys.py
@@ -146,7 +146,7 @@ class KojiProcessor(BaseProcessor):
             session = koji.ClientSession(url)
             build = msg['msg']
             long_form = self._fill_build_template(session, build)
-            return self.subtitle(msg, **config) + "\n\n" + long_form
+            return long_form
         if 'buildsys.task.state.change' in msg['topic'] and koji:
             session = koji.ClientSession(url)
             taskid = msg['msg']['id']
@@ -155,7 +155,7 @@ class KojiProcessor(BaseProcessor):
             except Exception as e:
                 log.warning(unicode(e))
                 long_form = unicode(e)
-            return self.subtitle(msg, **config) + "\n\n" + long_form
+            return long_form
 
     def subtitle(self, msg, **config):
         inst = msg['msg'].get('instance', 'primary')

--- a/fedmsg_meta_fedora_infrastructure/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/coprs.py
@@ -65,7 +65,7 @@ class CoprsProcessor(BaseProcessor):
             kwargs['status'] = _statuses.get(kwargs.get('status'), 'unknown')
 
             details = _long_template.format(**kwargs)
-            return self.subtitle(msg, **config) + "\n\n" + details
+            return details
 
     def subtitle(self, msg, **config):
 

--- a/fedmsg_meta_fedora_infrastructure/github.py
+++ b/fedmsg_meta_fedora_infrastructure/github.py
@@ -88,21 +88,21 @@ class GithubProcessor(BaseProcessor):
     def long_form(self, msg, **config):
         if '.pull_request_review_comment' in msg['topic']:
             body = msg['msg']['comment']['body']
-            return self.subtitle(msg, **config) + '\n\n' + body
+            return body
         if '.issue.comment' in msg['topic']:
             body = msg['msg']['comment']['body']
-            return self.subtitle(msg, **config) + '\n\n' + body
+            return body
         if '.issue.reopened' in msg['topic']:
             body = msg['msg']['issue']['body']
-            return self.subtitle(msg, **config) + '\n\n' + body
+            return body
         if 'commit_comment' in msg['topic']:
             body = msg['msg']['comment']['body']
-            return self.subtitle(msg, **config) + '\n\n' + body
+            return body
         elif 'github.push' in msg['topic']:
             url = msg['msg']['compare'] + ".patch"
             response = requests.get(url)
             if response.status_code == 200:
-                return self.subtitle(msg, **config) + '\n\n' + response.text
+                return response.text
 
     def subtitle(self, msg, **config):
         user = self._get_user(msg)

--- a/fedmsg_meta_fedora_infrastructure/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/scm.py
@@ -59,24 +59,18 @@ class SCMProcessor(BaseProcessor):
 
             seen = msg['msg']['commit'].get('seen', False)
             if seen:
-                return self.subtitle(msg, **config) + '\n\n' + already_seen_msg
+                return already_seen_msg
 
             url = 'http://pkgs.fedoraproject.org/cgit/' + \
                 '{repo}.git/patch/?id={rev}'
             response = requests.get(url.format(repo=repo, rev=rev))
             if response.status_code == 200:
-                return self.subtitle(msg, **config) + '\n\n' + response.text
+                return response.text
         elif '.git.lookaside' in msg['topic']:
-            name = msg['msg']['name']
-            agent = msg['msg']['agent']
             filename = msg['msg']['filename']
             xsum = msg['msg']['md5sum']
-            tmpl = self._(
-                "{agent} uploaded a file to the lookaside cache for {name}\n\n"
-                "{xsum}  {filename}"
-            )
-            return tmpl.format(
-                agent=agent, name=name, xsum=xsum, filename=filename)
+            tmpl = self._("{xsum}  {filename}")
+            return tmpl.format(xsum=xsum, filename=filename)
 
     def subtitle(self, msg, **config):
         if '.git.receive' in msg['topic']:

--- a/fedmsg_meta_fedora_infrastructure/supybot.py
+++ b/fedmsg_meta_fedora_infrastructure/supybot.py
@@ -47,7 +47,7 @@ class SupybotProcessor(BaseProcessor):
             url = msg['msg']['url'] + '.txt'
             response = requests.get(url)
             if response.status_code == 200:
-                return self.subtitle(msg, **config) + '\n\n' + response.text
+                return response.text
 
     def subtitle(self, msg, **config):
         action = None

--- a/fedmsg_meta_fedora_infrastructure/tests/__init__.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/__init__.py
@@ -366,8 +366,8 @@ class TestLookaside(Base):
         'texlive/pst-diffraction.doc.tar.xz/' + \
         'dacad985394b3977f9dcf0c75f51a357/' + \
         'pst-diffraction.doc.tar.xz'
-    expected_long_form = 'jnovy uploaded a file to the lookaside cache ' + \
-    'for texlive\n\ndacad985394b3977f9dcf0c75f51a357  pst-diffraction.doc.tar.xz'
+    expected_long_form = \
+        'dacad985394b3977f9dcf0c75f51a357  pst-diffraction.doc.tar.xz'
     expected_usernames = set(['jnovy'])
     expected_packages = set(['texlive'])
     expected_objects = set(['texlive/pst-diffraction.doc.tar.xz'])

--- a/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
@@ -582,16 +582,12 @@ if koji and not (
     'FEDMSG_META_NO_NETWORK' in os.environ or 'TRAVIS_CI' in os.environ):
 
     TestKojiBuildStateChangeComplete.expected_long_form = \
-        TestKojiBuildStateChangeComplete.expected_subti + "\n\n" + \
         _build_long_form_complete
     TestKojiBuildStateChangeFail.expected_long_form = \
-        TestKojiBuildStateChangeFail.expected_subti + "\n\n" + \
         _build_long_form_fail
     #TestKojiBuildStateChangeCancel.expected_long_form = \
-    #    TestKojiBuildStateChangeCancel.expected_subti + "\n\n" + \
     #    _build_long_form_cancel
     TestKojiTaskStateChangeFail.expected_long_form = \
-        TestKojiTaskStateChangeFail.expected_subti + "\n\n" + \
         _scratch_long_form_fail
 
 class TestKojiRepoInit(Base):

--- a/fedmsg_meta_fedora_infrastructure/tests/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/coprs.py
@@ -105,7 +105,7 @@ class TestCoprsBuildEnd(Base):
         "fatka's mutt-kz copr build of "
         "mutt-kz-1.5.23.1-1.20150203.git.c8504a8a.fc21 "
         "for fedora-20-x86_64 finished with 'success'")
-    expected_long_form = expected_subti + "\n\n" + _long_copr_end
+    expected_long_form = _long_copr_end
     expected_secondary_icon = (
         'https://seccdn.libravatar.org/avatar/'
         'b9d974c03597da48d9c3b11d4423bf30c6e0c01c23bcd3a192167a95f7c506bc?'
@@ -149,7 +149,7 @@ class TestCoprsBuildFailure(Base):
         "brianjmurrell's glib2 copr build of "
         "glib2-2.42.2-1.01.fc21 "
         "for fedora-21-x86_64 finished with 'failed'")
-    expected_long_form = expected_subti + "\n\n" + _long_copr_end_fail
+    expected_long_form = _long_copr_end_fail
     expected_secondary_icon = (
         'https://seccdn.libravatar.org/avatar/'
         '7de251444538e68ddf2e83d67749c5f09583ae7b3fd638df3490c7e672c148d8?'

--- a/fedmsg_meta_fedora_infrastructure/tests/github.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/github.py
@@ -2050,92 +2050,84 @@ class TestGithubMember(Base):
     expected_packages = set([])
     expected_usernames = set(['ralph'])
     expected_objects = set(['ralphbean/lightsaber/member'])
-    msg = {  
+    msg = {
         "source_name": "datanommer",
-        "i": 2, 
-        "timestamp": 1426257201.0, 
-        "msg_id": "2015-b21fdc03-9f22-4d6f-a086-74d4dae25b6c", 
-        "topic": "org.fedoraproject.prod.github.member", 
-        "source_version": "0.6.4", 
+        "i": 2,
+        "timestamp": 1426257201.0,
+        "msg_id": "2015-b21fdc03-9f22-4d6f-a086-74d4dae25b6c",
+        "topic": "org.fedoraproject.prod.github.member",
+        "source_version": "0.6.4",
         "msg": {
-            "action": "added", 
+            "action": "added",
             "member": {
-              "url": "https://api.github.com/users/decause", 
-              "site_admin": False, 
-              "html_url": "https://github.com/decause", 
-              "gravatar_id": "", 
-              "login": "decause", 
-              "type": "User", 
+              "url": "https://api.github.com/users/decause",
+              "site_admin": False,
+              "html_url": "https://github.com/decause",
+              "gravatar_id": "",
+              "login": "decause",
+              "type": "User",
               "id": 427420
-            }, 
+            },
             "fas_usernames": {
               "ralphbean": "ralph"
-            }, 
+            },
             "repository": {
-              "has_wiki": False, 
-              "has_pages": False, 
-              "updated_at": "2015-03-13T13:23:31Z", 
-              "private": False, 
-              "full_name": "ralphbean/lightsaber", 
+              "has_wiki": False,
+              "has_pages": False,
+              "updated_at": "2015-03-13T13:23:31Z",
+              "private": False,
+              "full_name": "ralphbean/lightsaber",
               "owner": {
-                "url": "https://api.github.com/users/ralphbean", 
-                "site_admin": False, 
-                "html_url": "https://github.com/ralphbean", 
-                "gravatar_id": "", 
-                "login": "ralphbean", 
-                "type": "User", 
+                "url": "https://api.github.com/users/ralphbean",
+                "site_admin": False,
+                "html_url": "https://github.com/ralphbean",
+                "gravatar_id": "",
+                "login": "ralphbean",
+                "type": "User",
                 "id": 331338
-              }, 
-              "id": 13132894, 
-              "size": 1397, 
-              "watchers_count": 15, 
-              "forks": 3, 
-              "homepage": "", 
-              "fork": False, 
-              "description": "Everyone has to build their own...", 
-              "has_downloads": True, 
-              "forks_count": 3, 
-              "default_branch": "develop", 
-              "html_url": "https://github.com/ralphbean/lightsaber", 
-              "has_issues": True, 
-              "stargazers_count": 15, 
-              "open_issues_count": 1, 
-              "watchers": 15, 
-              "name": "lightsaber", 
-              "language": "Python", 
-              "url": "https://api.github.com/repos/ralphbean/lightsaber", 
-              "created_at": "2013-09-26T20:00:13Z", 
-              "pushed_at": "2015-03-13T13:23:31Z", 
+              },
+              "id": 13132894,
+              "size": 1397,
+              "watchers_count": 15,
+              "forks": 3,
+              "homepage": "",
+              "fork": False,
+              "description": "Everyone has to build their own...",
+              "has_downloads": True,
+              "forks_count": 3,
+              "default_branch": "develop",
+              "html_url": "https://github.com/ralphbean/lightsaber",
+              "has_issues": True,
+              "stargazers_count": 15,
+              "open_issues_count": 1,
+              "watchers": 15,
+              "name": "lightsaber",
+              "language": "Python",
+              "url": "https://api.github.com/repos/ralphbean/lightsaber",
+              "created_at": "2013-09-26T20:00:13Z",
+              "pushed_at": "2015-03-13T13:23:31Z",
               "open_issues": 1
-            }, 
+            },
             "sender": {
-              "url": "https://api.github.com/users/ralphbean", 
-              "site_admin": False, 
-              "html_url": "https://github.com/ralphbean", 
-              "gravatar_id": "", 
-              "login": "ralphbean", 
-              "type": "User", 
+              "url": "https://api.github.com/users/ralphbean",
+              "site_admin": False,
+              "html_url": "https://github.com/ralphbean",
+              "gravatar_id": "",
+              "login": "ralphbean",
+              "type": "User",
               "id": 331338
             }
         }
     }
 
 
-
-
 if not 'FEDMSG_META_NO_NETWORK' in os.environ:
-    TestGithubPush.expected_long_form = \
-        TestGithubPush.expected_subti + "\n\n" + full_patch1
-    TestGithubIssue.expected_long_form = \
-        TestGithubIssue.expected_subti + "\n\n" + "Testing stuff."
-    TestGithubIssueComment.expected_long_form = \
-        TestGithubIssueComment.expected_subti + "\n\n" + \
-        "This issue is super great!"
+    TestGithubPush.expected_long_form = full_patch1
+    TestGithubIssue.expected_long_form = "Testing stuff."
+    TestGithubIssueComment.expected_long_form = "This issue is super great!"
     TestGithubPullRequestComment.expected_long_form = \
-        TestGithubPullRequestComment.expected_subti + "\n\n" + \
         "I was thinking the ``flask.request.args.get(..."
     TestGithubCommitComment.expected_long_form = \
-        TestGithubCommitComment.expected_subti + "\n\n" + \
         "Maybe add a ``# comment`` here that 'BUILD_ID' " + \
         "is from jenkins and link to http://da.gd/QuQs ?"
 

--- a/fedmsg_meta_fedora_infrastructure/tests/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/scm.py
@@ -196,8 +196,7 @@ class TestSCM(Base):
     expected_link = "http://pkgs.fedoraproject.org/cgit/" + \
         "valgrind.git/commit/" + \
         "?h=master&id=7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1"
-    expected_long_form = expected_subti + "\n\n" + \
-        "This commit already existed in another branch."
+    expected_long_form = "This commit already existed in another branch."
     expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
     expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
         "0f32874b1ae3083205c874c83cd2d21715c89b8645483f353e90ae499c67c944"
@@ -294,9 +293,7 @@ class TestSCMSingleLine(Base):
     }
 
 if not 'FEDMSG_META_NO_NETWORK' in os.environ:
-    TestGitReceiveOldModified.expected_long_form = \
-        TestGitReceiveOldModified.expected_subti + "\n\n" + \
-        full_patch
+    TestGitReceiveOldModified.expected_long_form = full_patch
 
 
 add_doc(locals())

--- a/fedmsg_meta_fedora_infrastructure/tests/trac.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/trac.py
@@ -49,7 +49,7 @@ class TestTracTicketCreate(Base):
 
     expected_title = "trac.ticket.new"
     expected_subti = "ralph opened a new ticket on the moksha trac instance"
-    expected_long_form = expected_subti + "\n\n" + _long_form_new
+    expected_long_form = _long_form_new
     expected_secondary_icon = (
         "https://seccdn.libravatar.org/avatar/"
         "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
@@ -106,7 +106,7 @@ class TestTracTicketChange(Base):
 
     expected_title = "trac.ticket.update"
     expected_subti = "ralph updated a ticket on the moksha trac instance"
-    expected_long_form = expected_subti + "\n\n" + _long_form_comment
+    expected_long_form = _long_form_comment
     expected_secondary_icon = (
         "https://seccdn.libravatar.org/avatar/"
         "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
@@ -167,7 +167,7 @@ class TestTracTicketChangeReopen(Base):
 
     expected_title = "trac.ticket.update"
     expected_subti = "ralph reopened a ticket on the moksha trac instance"
-    expected_long_form = expected_subti + "\n\n" + _long_form_reopen
+    expected_long_form = _long_form_reopen
     expected_secondary_icon = (
         "https://seccdn.libravatar.org/avatar/"
         "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
@@ -232,7 +232,7 @@ class TestTracTicketChangeClosed(Base):
     expected_title = "trac.ticket.update"
     expected_subti = ("ralph closed a ticket on the moksha trac "
                       "instance as 'wontfix'")
-    expected_long_form = expected_subti + "\n\n" + _long_form_closed
+    expected_long_form = _long_form_closed
     expected_secondary_icon = (
         "https://seccdn.libravatar.org/avatar/"
         "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"

--- a/fedmsg_meta_fedora_infrastructure/tests/zodbot.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/zodbot.py
@@ -465,8 +465,7 @@ class TestSupybotKarma(Base):
 
 
 if not 'FEDMSG_META_NO_NETWORK' in os.environ:
-    TestSupybotEndMeeting.expected_long_form = \
-        TestSupybotEndMeeting.expected_subti + "\n\n" + full_irc_logs
+    TestSupybotEndMeeting.expected_long_form = full_irc_logs
 
 
 add_doc(locals())

--- a/fedmsg_meta_fedora_infrastructure/trac.py
+++ b/fedmsg_meta_fedora_infrastructure/trac.py
@@ -110,7 +110,7 @@ class TracProcessor(BaseProcessor):
                 retval += "Comment: " + comment + "\n"
             elif description:
                 retval += "Description: " + description + "\n"
-            return self.subtitle(msg, **config) + "\n\n" + retval
+            return retval
 
     def subtitle(self, msg, **config):
         if 'page' in msg['msg']:


### PR DESCRIPTION
Before this, we would include the 'subtitle' as a part of every long_form
representation and it just seems kind of silly now.  It means that, for emails
there would be the Subject with the subtitle, then the contents of the email
would contain the subtitle *again* followed by the long_form.  This gets rid of
that duplicate in there.

We'll have to make one other change to fmn.consumer to tell it to **do**
included the subtitle if the messages show up in a batch email, since the
'Subject' won't be there to clarify.