### PR TITLE
Feature/improve fedimg details

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -34,15 +34,12 @@ class FedimgProcessor(BaseProcessor):
             if msg['msg']['status'] == "started":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('{image_name} started uploading to to {dest}')
                 return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "completed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                extra = ', '.join(msg['msg']['extra'].keys())
-                tmpl = self._('{image_name} finished uploading to to {dest} '
-                              '({extra})')
-                return tmpl.format(image_name=name, dest=dest, extra=extra)
+                tmpl = self._('{image_name} finished uploading to {dest}')
+                return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "failed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
@@ -52,21 +49,16 @@ class FedimgProcessor(BaseProcessor):
             if msg['msg']['status'] == "started":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                extra = ', '.join(msg['msg']['extra'].keys())
-                tmpl = self._('{image_name} started testing on {dest} '
-                              '({extra})')
-                return tmpl.format(image_name=name, dest=dest, extra=extra)
+                extra = msg['msg']['extra']
+                tmpl = self._('{image_name} started testing on {dest}')
+                return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "completed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                extra = ', '.join(msg['msg']['extra'].keys())
-                tmpl = self._('{image_name} finished testing on {dest} '
-                              '({extra})')
-                return tmpl.format(image_name=name, dest=dest, extra=extra)
+                tmpl = self._('{image_name} finished testing on {dest}')
+                return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "failed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                extra = ', '.join(msg['msg']['extra'].keys())
-                tmpl = self._('{image_name} failed testing on {dest} '
-                              '({extra})')
-                return tmpl.format(image_name=name, dest=dest, extra=extra)
+                tmpl = self._('{image_name} failed testing on {dest}')
+                return tmpl.format(image_name=name, dest=dest)

--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -34,6 +34,7 @@ class FedimgProcessor(BaseProcessor):
             if msg['msg']['status'] == "started":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
+                tmpl = self._('{image_name} started uploading to {dest}')
                 return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "completed":
                 name = msg['msg']['image_name']

--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -30,39 +30,40 @@ class FedimgProcessor(BaseProcessor):
     __icon__ = "https://apps.fedoraproject.org/img/icons/fedimg.png"
 
     def subtitle(self, msg, **config):
+        name = msg['msg']['image_name']
+        dest = msg['msg']['destination']
         if 'image.upload' in msg['topic']:
             if msg['msg']['status'] == "started":
-                name = msg['msg']['image_name']
-                dest = msg['msg']['destination']
                 tmpl = self._('{image_name} started uploading to {dest}')
                 return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "completed":
-                name = msg['msg']['image_name']
-                dest = msg['msg']['destination']
-                tmpl = self._('{image_name} finished uploading to {dest}')
-                return tmpl.format(image_name=name, dest=dest)
+                ami = msg['msg']['extra']['id']
+                virt = msg['msg']['extra']['virt_type']
+                vol = msg['msg']['extra']['vol_type']
+                tmpl = self._('{image_name} finished uploading to {dest} '
+                              '({ami}, {virt}, {vol})')
+                return tmpl.format(image_name=name, dest=dest, ami=ami,
+                                   virt=virt, vol=vol)
             elif msg['msg']['status'] == "failed":
-                name = msg['msg']['image_name']
-                dest = msg['msg']['destination']
                 tmpl = self._('{image_name} failed to upload to {dest}')
                 return tmpl.format(image_name=name, dest=dest)
         if 'image.test' in msg['topic']:
+            tmpl = ''
+            ami = msg['msg']['extra']['id']
+            virt = msg['msg']['extra']['virt_type']
+            vol = msg['msg']['extra']['vol_type']
             if msg['msg']['status'] == "started":
-                name = msg['msg']['image_name']
-                dest = msg['msg']['destination']
                 extra = msg['msg']['extra']
-                tmpl = self._('{image_name} started testing on {dest}')
-                return tmpl.format(image_name=name, dest=dest)
+                tmpl = self._('{image_name} started testing on {dest} '
+                              '({ami}, {virt}, {vol})')
             elif msg['msg']['status'] == "completed":
-                name = msg['msg']['image_name']
-                dest = msg['msg']['destination']
-                tmpl = self._('{image_name} finished testing on {dest}')
-                return tmpl.format(image_name=name, dest=dest)
+                tmpl = self._('{image_name} finished testing on {dest} '
+                              '({ami}, {virt}, {vol})')
             elif msg['msg']['status'] == "failed":
-                name = msg['msg']['image_name']
-                dest = msg['msg']['destination']
-                tmpl = self._('{image_name} failed testing on {dest}')
-                return tmpl.format(image_name=name, dest=dest)
+                tmpl = self._('{image_name} failed testing on {dest} '
+                              '({ami}, {virt}, {vol})')
+            return tmpl.format(image_name=name, dest=dest, ami=ami,
+                               virt=virt, vol=vol)
 
     def objects(self, msg, **config):
         status = msg['msg']['status']

--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -24,7 +24,6 @@ class FedimgProcessor(BaseProcessor):
     __name__ = "fedimg"
     __description__ = "The Fedora cloud image service"
     __link__ = "https://github.com/oddshocks/fedimg"
-    # TODO: Create an icon and set its URL to __icon__
     __docs__ = "https://fedoraproject.org/wiki/Features/" + \
                "FirstClassCloudImages/KojiPlan"
     __obj__ = "New cloud image upload"

--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -34,6 +34,7 @@ class FedimgProcessor(BaseProcessor):
             if msg['msg']['status'] == "started":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
+                tmpl = self._('{image_name} started uploading to to {dest}')
                 return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "completed":
                 name = msg['msg']['image_name']

--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -62,3 +62,10 @@ class FedimgProcessor(BaseProcessor):
                 dest = msg['msg']['destination']
                 tmpl = self._('{image_name} failed testing on {dest}')
                 return tmpl.format(image_name=name, dest=dest)
+
+    def objects(self, msg, **config):
+        status = msg['msg']['status']
+        if 'image.upload' in msg['topic']:
+            return set(['image/upload/' + status])
+        elif 'image.test' in msg['topic']:
+            return set(['image/test/' + status])

--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -39,8 +39,10 @@ class FedimgProcessor(BaseProcessor):
             elif msg['msg']['status'] == "completed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('{image_name} finished uploading to to {dest}')
-                return tmpl.format(image_name=name, dest=dest)
+                extra = ', '.join(msg['msg']['extra'].keys())
+                tmpl = self._('{image_name} finished uploading to to {dest} '
+                              '({extra})')
+                return tmpl.format(image_name=name, dest=dest, extra=extra)
             elif msg['msg']['status'] == "failed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
@@ -50,15 +52,21 @@ class FedimgProcessor(BaseProcessor):
             if msg['msg']['status'] == "started":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('{image_name} started testing on {dest}')
-                return tmpl.format(image_name=name, dest=dest)
+                extra = ', '.join(msg['msg']['extra'].keys())
+                tmpl = self._('{image_name} started testing on {dest} '
+                              '({extra})')
+                return tmpl.format(image_name=name, dest=dest, extra=extra)
             elif msg['msg']['status'] == "completed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('{image_name} finished testing on {dest}')
-                return tmpl.format(image_name=name, dest=dest)
+                extra = ', '.join(msg['msg']['extra'].keys())
+                tmpl = self._('{image_name} finished testing on {dest} '
+                              '({extra})')
+                return tmpl.format(image_name=name, dest=dest, extra=extra)
             elif msg['msg']['status'] == "failed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('{image_name} failed testing on {dest}')
-                return tmpl.format(image_name=name, dest=dest)
+                extra = ', '.join(msg['msg']['extra'].keys())
+                tmpl = self._('{image_name} failed testing on {dest} '
+                              '({extra})')
+                return tmpl.format(image_name=name, dest=dest, extra=extra)

--- a/fedmsg_meta_fedora_infrastructure/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/fedimg.py
@@ -35,31 +35,30 @@ class FedimgProcessor(BaseProcessor):
             if msg['msg']['status'] == "started":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('Image {image_name} started uploading to {dest}')
                 return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "completed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('Image {image_name} finished uploading to to {dest}')
+                tmpl = self._('{image_name} finished uploading to to {dest}')
                 return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "failed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('Image {image_name} failed to upload to {dest}')
+                tmpl = self._('{image_name} failed to upload to {dest}')
                 return tmpl.format(image_name=name, dest=dest)
         if 'image.test' in msg['topic']:
             if msg['msg']['status'] == "started":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('Image {image_name} started testing on {dest}')
+                tmpl = self._('{image_name} started testing on {dest}')
                 return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "completed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('Image {image_name} finished testing on {dest}')
+                tmpl = self._('{image_name} finished testing on {dest}')
                 return tmpl.format(image_name=name, dest=dest)
             elif msg['msg']['status'] == "failed":
                 name = msg['msg']['image_name']
                 dest = msg['msg']['destination']
-                tmpl = self._('Image {image_name} failed testing on {dest}')
+                tmpl = self._('{image_name} failed testing on {dest}')
                 return tmpl.format(image_name=name, dest=dest)

--- a/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
@@ -27,7 +27,10 @@ from .common import add_doc
 
 
 class TestImageUploadStart(Base):
-    """ These messages are awarded when an image upload has started. """
+    """ These messages are awarded when an image upload has started. 
+        At this point, Fedimg has picked up a completed Koji
+        createImage task and will begin the process of registering
+        the .raw.xz file as as an image with a cloud provider. """
 
     expected_title = "fedimg.image.upload"
     image_name = "fedora-cloud-base-rawhide-20140604.x86_64"
@@ -57,7 +60,9 @@ class TestImageUploadStart(Base):
 
 
 class TestImageUploadComplete(Base):
-    """ These messages are awarded when an image upload finishes. """
+    """ These messages are awarded when an image upload finishes.
+        At this point, Fedimg has completed registering a .raw.xz
+        image with a cloud provider. """
 
     expected_title = "fedimg.image.upload"
     image_name = "fedora-cloud-base-rawhide-20140604.x86_64"
@@ -95,7 +100,10 @@ class TestImageUploadComplete(Base):
 
 
 class TestImageTestStart(Base):
-    """ These messages are awarded when an image test has started. """
+    """ These messages are awarded when an image test has started.
+        At this point, Fedimg tries to start an instance of a
+        image that it registered in the previous step, and check
+        to see that it's running properly. """
 
     expected_title = "fedimg.image.test"
     image_name = "fedora-cloud-base-rawhide-20140604.x86_64"

--- a/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
@@ -42,7 +42,7 @@ class TestImageUploadStart(Base):
     expected_secondary_icon = None
     expected_packages = set([])
     expected_usernames = set([])
-    expected_objects = set([])
+    expected_objects = set(['image/upload/started'])
     msg = {
         u'i': 1,
         u'msg': {
@@ -77,7 +77,7 @@ class TestImageUploadComplete(Base):
     expected_secondary_icon = None
     expected_packages = set([])
     expected_usernames = set([])
-    expected_objects = set([])
+    expected_objects = set(['image/upload/completed'])
     msg = {
         u'i': 1,
         u'msg': {
@@ -118,7 +118,7 @@ class TestImageTestStart(Base):
     expected_secondary_icon = None
     expected_packages = set([])
     expected_usernames = set([])
-    expected_objects = set([])
+    expected_objects = set(['image/test/started'])
     msg = {
         u'i': 1,
         u'msg': {

--- a/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
@@ -35,7 +35,7 @@ class TestImageUploadStart(Base):
     expected_subti = "{0} started uploading to {1}".format(image_name,
                                                                  dest)
     expected_link = None
-    expected_icon = None
+    expected_icon = 'https://apps.fedoraproject.org/img/icons/fedimg.png'
     expected_secondary_icon = None
     expected_packages = set([])
     expected_usernames = set([])

--- a/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
@@ -27,7 +27,7 @@ from .common import add_doc
 
 
 class TestImageUploadStart(Base):
-    """ These messages are awarded when an image upload has started. 
+    """ These messages are published when an image upload has started. 
         At this point, Fedimg has picked up a completed Koji
         createImage task and will begin the process of registering
         the .raw.xz file as as an image with a cloud provider. """
@@ -60,7 +60,7 @@ class TestImageUploadStart(Base):
 
 
 class TestImageUploadComplete(Base):
-    """ These messages are awarded when an image upload finishes.
+    """ These messages are published when an image upload finishes.
         At this point, Fedimg has completed registering a .raw.xz
         image with a cloud provider. """
 
@@ -100,7 +100,7 @@ class TestImageUploadComplete(Base):
 
 
 class TestImageTestStart(Base):
-    """ These messages are awarded when an image test has started.
+    """ These messages are published when an image test has started.
         At this point, Fedimg tries to start an instance of a
         image that it registered in the previous step, and check
         to see that it's running properly. """

--- a/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
@@ -56,9 +56,46 @@ class TestImageUploadStart(Base):
     }
 
 
-class TestImageTest(Base):
-    """ These messages are awarded when an image starts has started,
-    completes, or fails. """
+class TestImageUploadComplete(Base):
+    """ These messages are awarded when an image upload finishes. """
+
+    expected_title = "fedimg.image.upload"
+    image_name = "fedora-cloud-base-rawhide-20140604.x86_64"
+    dest = "EC2-eu-west-1"
+    ami_id = 'ami-1234fda'
+    virt_type = 'HVM'
+    vol_type = 'gp2'
+    expected_subti = "{0} finished uploading to {1} ({2}, {3}, {4})".format(
+            image_name, dest, ami_id, virt_type, vol_type)
+    expected_link = None
+    expected_icon = None
+    expected_secondary_icon = None
+    expected_packages = set([])
+    expected_usernames = set([])
+    expected_objects = set([])
+    msg = {
+        u'i': 1,
+        u'msg': {
+            u'image_url': 'https://kojipkgs.fedoraproject.org//work/'
+                          'tasks/5144/6925144/fedora-cloud-base-'
+                          'rawhide-20140604.x86_64.raw.xz',
+            u'image_name': 'fedora-cloud-base-rawhide-20140604.x86_64',
+            u'destination': 'EC2-eu-west-1',
+            u'status': 'completed',
+            u'extra': {
+                u'id': 'ami-1234fda',
+                u'virt_type': 'HVM',
+                u'vol_type': 'gp2',
+            },
+        },
+        u'topic': u'org.fedoraproject.stg.fedimg.image.upload',
+        u'username': u'fedimg',
+        u'timestamp': 1371498303.125771,
+    }
+
+
+class TestImageTestStart(Base):
+    """ These messages are awarded when an image test has started. """
 
     expected_title = "fedimg.image.test"
     image_name = "fedora-cloud-base-rawhide-20140604.x86_64"

--- a/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
@@ -26,14 +26,13 @@ from fedmsg.tests.test_meta import Base
 from .common import add_doc
 
 
-class TestImageUpload(Base):
-    """ These messages are awarded when an image starts has started,
-    completes, or fails. """
+class TestImageUploadStart(Base):
+    """ These messages are awarded when an image upload has started. """
 
     expected_title = "fedimg.image.upload"
     image_name = "fedora-cloud-base-rawhide-20140604.x86_64"
     dest = "EC2-eu-west-1"
-    expected_subti = "Image {0} started uploading to {1}".format(image_name,
+    expected_subti = "{0} started uploading to {1}".format(image_name,
                                                                  dest)
     expected_link = None
     expected_icon = None
@@ -64,8 +63,11 @@ class TestImageTest(Base):
     expected_title = "fedimg.image.test"
     image_name = "fedora-cloud-base-rawhide-20140604.x86_64"
     dest = "EC2-eu-west-1"
-    expected_subti = "Image {0} started testing on {1}".format(image_name,
-                                                                 dest)
+    ami_id = 'ami-1234fda'
+    virt_type = 'HVM'
+    vol_type = 'gp2'
+    expected_subti = "{0} started testing on {1} ({2}, {3}, {4})".format(
+            image_name, dest, ami_id, virt_type, vol_type)
     expected_link = None
     expected_icon = None
     expected_secondary_icon = None
@@ -81,6 +83,11 @@ class TestImageTest(Base):
             u'image_name': 'fedora-cloud-base-rawhide-20140604.x86_64',
             u'destination': 'EC2-eu-west-1',
             u'status': 'started',
+            u'extra': {
+                u'id': 'ami-1234fda',
+                u'virt_type': 'HVM',
+                u'vol_type': 'gp2',
+            },
         },
         u'topic': u'org.fedoraproject.stg.fedimg.image.test',
         u'username': u'fedimg',

--- a/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/fedimg.py
@@ -73,7 +73,7 @@ class TestImageUploadComplete(Base):
     expected_subti = "{0} finished uploading to {1} ({2}, {3}, {4})".format(
             image_name, dest, ami_id, virt_type, vol_type)
     expected_link = None
-    expected_icon = None
+    expected_icon = 'https://apps.fedoraproject.org/img/icons/fedimg.png'
     expected_secondary_icon = None
     expected_packages = set([])
     expected_usernames = set([])
@@ -114,7 +114,7 @@ class TestImageTestStart(Base):
     expected_subti = "{0} started testing on {1} ({2}, {3}, {4})".format(
             image_name, dest, ami_id, virt_type, vol_type)
     expected_link = None
-    expected_icon = None
+    expected_icon = 'https://apps.fedoraproject.org/img/icons/fedimg.png'
     expected_secondary_icon = None
     expected_packages = set([])
     expected_usernames = set([])


### PR DESCRIPTION
With this PR, a little extra info will be printed out for Fedimg jobs, when applicable. Users will be able to see AMI ID, virtualization type, and volume type in the Fedmsg subtitle.

Also updated the tests for Fedimg stuff and added a new test. Tests run without error, but I could have made a mistake somewhere, or maybe there's something I could have done better? :)