### PR TITLE
Add and test an infragit processor.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/infragit.py
+++ b/fedmsg_meta_fedora_infrastructure/infragit.py
@@ -1,0 +1,79 @@
+# This file is part of fedmsg.
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+from fedmsg_meta_fedora_infrastructure import BaseProcessor
+from fedmsg_meta_fedora_infrastructure.fasshim import avatar_url
+
+
+class InfraGitProcessor(BaseProcessor):
+    __name__ = "infragit"
+    __description__ = "Fedora Infrastructure repos"
+    __link__ = "https://infrastructure.fedoraproject.org/cgit/"
+    __docs__ = "https://fedoraproject.org/wiki/Using_Fedora_GIT"
+    __docs__ = "https://infrastructure.fedoraproject.org/infra/" + \
+        "docs/infra-git-repo.rst"
+    __obj__ = "Infrastructure Commits"
+    __icon__ = "https://apps.fedoraproject.org/img/icons/git-logo.png"
+
+    def _get_repo(self, msg):
+        return msg['msg']['commit']['path'].split('/')[-1]
+
+    def subtitle(self, msg, **config):
+        repo = self._get_repo(msg)
+        user = self.agent(msg, **config)
+
+        summ = msg['msg']['commit']['summary']
+        whole = msg['msg']['commit']['message']
+        if summ.strip() != whole.strip():
+            summ += " (..more)"
+
+        branch = msg['msg']['commit']['branch']
+
+        tmpl = self._('{user} pushed a commit to the fedora-infra {repo} repo '
+                      '({branch}):  "{summary}"')
+        return tmpl.format(user=user, repo=repo, branch=branch, summary=summ)
+
+    def link(self, msg, **config):
+        prefix = "https://infrastructure.fedoraproject.org/cgit"
+        repo = self._get_repo(msg)
+
+        # We don't have public links to some old repos..
+        if repo in ['puppet']:
+            return ''
+
+        rev = msg['msg']['commit']['rev']
+        branch = msg['msg']['commit']['branch']
+        tmpl = "{prefix}/{repo}.git/commit/?h={branch}&id={rev}"
+        return tmpl.format(prefix=prefix, repo=repo, branch=branch, rev=rev)
+
+    def secondary_icon(self, msg, **config):
+        return avatar_url(self.agent(msg, **config))
+
+    def usernames(self, msg, **config):
+        return set([self.agent(msg, **config)])
+
+    def agent(self, msg, **config):
+        return msg['msg']['commit']['username']
+
+    def objects(self, msg, **config):
+        repo = self._get_repo(msg)
+        return set([
+            repo + '/' + filename
+            for filename in msg['msg']['commit']['stats']['files']
+        ])

--- a/fedmsg_meta_fedora_infrastructure/tests/__init__.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/__init__.py
@@ -56,6 +56,7 @@ from fedmsg_meta_fedora_infrastructure.tests.zodbot import *
 from fedmsg_meta_fedora_infrastructure.tests.faf import *
 from fedmsg_meta_fedora_infrastructure.tests.pagure import *
 from fedmsg_meta_fedora_infrastructure.tests.autocloud import *
+from fedmsg_meta_fedora_infrastructure.tests.infragit import *
 
 from fedmsg_meta_fedora_infrastructure.tests.base import Base
 

--- a/fedmsg_meta_fedora_infrastructure/tests/infragit.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/infragit.py
@@ -1,0 +1,152 @@
+# This file is part of fedmsg.
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors: Ralph Bean <rbean@redhat.com>
+#
+""" Tests for infra git messages (ansible, dns, etc..) """
+
+import unittest
+
+from fedmsg_meta_fedora_infrastructure.tests.base import Base
+
+from .common import add_doc
+
+
+class TestInfraGitPuppet(Base):
+    """ These messages get published by git repos owned by the Fedora
+    Infrastructure team.  These are the repos we use to manage the systems that
+    run fedoraproject.org.
+
+    In particular, this message is an example of a message from our "puppet"
+    repo, which is older and being retired in favor of our ansible repo.
+    """
+    expected_title = "infragit.receive"
+    expected_subti = 'ralph pushed a commit to the fedora-infra puppet ' + \
+        'repo (master):  "Testing again for fedmsg."'
+    expected_link = ''  # No links for puppet
+    expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
+    expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
+        "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
+        "?s=64&d=retro")
+    expected_usernames = set(['ralph'])
+    expected_agent = 'ralph'
+    expected_packages = set()
+    expected_objects = set(['puppet/test'])
+    msg = {
+        "i": 1,
+        "timestamp": 1439584387.0,
+        "msg_id": "2015-ee126d0a-a89b-4a09-ba15-4ca3382eb8fe",
+        "topic": "org.fedoraproject.prod.infragit.receive",
+        "source_version": "0.6.5",
+        "msg": {
+            "commit": {
+                "username": "ralph",
+                "stats": {
+                    "files": {
+                        "test": {
+                            "deletions": 0,
+                            "additions": 0,
+                            "lines": 0
+                        }
+                    },
+                    "total": {
+                        "deletions": 0,
+                        "files": 1,
+                        "additions": 0,
+                        "lines": 0
+                    }
+                },
+                "name": "Ralph Bean",
+                "rev": "6e7177a1d5fd712cb53ce70acb17b92c5f791f08",
+                "agent": "ralph",
+                "summary": "Testing again for fedmsg.",
+                "repo": "",
+                "branch": "master",
+                "seen": False,
+                "path": "/git/puppet",
+                "message": "Testing again for fedmsg.\n",
+                "email": "rbean@redhat.com"
+            }
+        }
+    }
+
+
+class TestInfraGitAnsible(Base):
+    """ These messages get published by git repos owned by the Fedora
+    Infrastructure team.  These are the repos we use to manage the systems that
+    run fedoraproject.org.
+
+    In particular, this message is an example of a message from our "ansible"
+    repo, which is where we do most of our work.
+    """
+    expected_title = "infragit.receive"
+    expected_subti = 'ralph pushed a commit to the fedora-infra ansible ' + \
+        'repo (master):  "Testing again for fedmsg."'
+    expected_link = "https://infrastructure.fedoraproject.org/cgit/" + \
+        "ansible.git/commit/" + \
+        "?h=master&id=6e7177a1d5fd712cb53ce70acb17b92c5f791f08"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
+    expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
+        "9c9f7784935381befc302fe3c814f9136e7a33953d0318761669b8643f4df55c"
+        "?s=64&d=retro")
+    expected_usernames = set(['ralph'])
+    expected_agent = 'ralph'
+    expected_packages = set()
+    expected_objects = set(['ansible/test'])
+    msg = {
+        "i": 1,
+        "timestamp": 1439584387.0,
+        "msg_id": "2015-ee126d0a-a89b-4a09-ba15-4ca3382eb8fe",
+        "topic": "org.fedoraproject.prod.infragit.receive",
+        "source_version": "0.6.5",
+        "msg": {
+            "commit": {
+                "username": "ralph",
+                "stats": {
+                    "files": {
+                        "test": {
+                            "deletions": 0,
+                            "additions": 0,
+                            "lines": 0
+                        }
+                    },
+                    "total": {
+                        "deletions": 0,
+                        "files": 1,
+                        "additions": 0,
+                        "lines": 0
+                    }
+                },
+                "name": "Ralph Bean",
+                "rev": "6e7177a1d5fd712cb53ce70acb17b92c5f791f08",
+                "agent": "ralph",
+                "summary": "Testing again for fedmsg.",
+                "repo": "",
+                "branch": "master",
+                "seen": False,
+                "path": "/git/ansible",
+                "message": "Testing again for fedmsg.\n",
+                "email": "rbean@redhat.com"
+            }
+        }
+    }
+
+
+add_doc(locals())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,8 @@ entry_points = {
         "faf=fedmsg_meta_fedora_infrastructure.faf:FAFProcessor",
         "autocloud=fedmsg_meta_fedora_infrastructure.autocloud:"
         "AutoCloudProcessor",
+        "infragit=fedmsg_meta_fedora_infrastructure.infragit:"
+        "InfraGitProcessor",
     ]
 }
 


### PR DESCRIPTION
@relrod wrote a proof of concept of a git hook for our infrastructure git
repos.  We tested it with the puppet repo and [it worked](https://apps.fedoraproject.org/datagrepper/id?id=2015-ee126d0a-a89b-4a09-ba15-4ca3382eb8fe&is_raw=true&size=extra-large)

With this processor merged and deployed, we should be able to add the hook for
our others (like dns, infra-docs, ansible, etc...).