### PR TITLE
Improve the doc with the list of topics.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,3 +51,12 @@ Running the Tests
 
     # Run the tests
     $ python setup.py test
+
+Building the Docs
+-----------------
+
+::
+
+    # Install additional dependencies
+    $ pip install mako sphinx
+    $ sphinx-build doc/ htmldocs/

--- a/fedmsg_meta_fedora_infrastructure/doc_utilities.py
+++ b/fedmsg_meta_fedora_infrastructure/doc_utilities.py
@@ -98,6 +98,19 @@ def write(fname, s=''):
     outfile.write(s + '\n')
 
 
+def datagrepper_link(topic):
+    suffix = '.'.join(topic.split('.')[3:])
+    category = topic.split('.')[3]
+    base_url = 'https://apps.fedoraproject.org/datagrepper/raw'
+    topic_link = base_url + '?topic=%s' % topic
+    category_link = base_url + '?category=%s' % category
+    tmpl = (
+        "You can view the history of `messages with the %s topic <%s>`_ "
+        "or `all %s messages <%s>`_ in datagrepper."
+    )
+    return tmpl % (suffix, topic_link, category, category_link)
+
+
 def load_classes(module):
     return list(nose.loader.defaultTestLoader().loadTestsFromModule(module))
 
@@ -165,6 +178,9 @@ def make_topics_doc(output_dir):
             if getattr(cls.context, 'doc', None):
                 write(fname, textwrap.dedent("    " + cls.context.doc.strip()))
                 write(fname)
+
+            write(fname, datagrepper_link(cls.context.msg['topic']))
+            write(fname)
 
             write(fname, ".. code-block:: python")
             write(fname, '\n    ' + pprint.pformat(cls.context.msg, indent=2)

--- a/fedmsg_meta_fedora_infrastructure/doc_utilities.py
+++ b/fedmsg_meta_fedora_infrastructure/doc_utilities.py
@@ -14,6 +14,8 @@ import nose
 import pprint
 import textwrap
 
+from fedmsg.tests.test_meta import Unspecified
+
 header = """
 List of Message Topics
 ======================
@@ -135,7 +137,7 @@ def make_topics_doc(output_dir):
     write(fname, header)
 
     for cls in test_classes:
-        if cls.context.msg:
+        if not cls.context.msg is Unspecified:
             # Adjust {stg,dev} to prod.
             cls.context.msg['topic'] = cls.context.msg['topic']\
                 .replace('.stg.', '.prod.')\
@@ -154,7 +156,7 @@ def make_topics_doc(output_dir):
 
     seen = []
     for cls in test_classes:
-        if cls.context.msg:
+        if not cls.context.msg is Unspecified:
             topic = cls.__topic
 
             # Ignore tests that check old messages.

--- a/fedmsg_meta_fedora_infrastructure/doc_utilities.py
+++ b/fedmsg_meta_fedora_infrastructure/doc_utilities.py
@@ -9,10 +9,13 @@ This code:
 
 """
 
-import os
 import nose
 import pprint
 import textwrap
+import uuid
+
+import mako.template
+import six
 
 from fedmsg.tests.test_meta import Unspecified
 
@@ -43,51 +46,42 @@ as well as descriptions and sample output from ``fedmsg.meta``.
 
 """
 
-metadata_template = """
+metadata_template = mako.template.Template("""
 The example message above, when passed to various routines in the
 :mod:`fedmsg.meta` module, will produce the following outputs:
 
-- :func:`fedmsg.meta.msg2title`
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2title`           | ${str(title).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2subtitle`        | ${str(subtitle).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2link`            | ${str(link).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2agent`           | ${str(agent).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2usernames`       | ${repr(usernames).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2packages`        | ${repr(packages).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2objects`         | ${repr(objects).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2icon`            | ${str(icon_inline).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
+| :func:`fedmsg.meta.msg2secondary_icon`  | ${str(secondary_icon_inline).ljust(longest)} |
++-----------------------------------------+${'-' * (longest + 2)}+
 
-  - {title}
+% if not icon is Unspecified:
+.. ${icon_inline} image:: ${icon}
+   :height: 32px
+   :width: 32px
+% endif
+% if not secondary_icon is Unspecified:
+.. ${secondary_icon_inline} image:: ${secondary_icon}
+   :height: 32px
+   :width: 32px
+% endif
 
-- :func:`fedmsg.meta.msg2subtitle`
-
-  - {subtitle}
-
-- :func:`fedmsg.meta.msg2link`
-
-  - {link}
-
-- :func:`fedmsg.meta.msg2icon`
-
-  - {icon}
-
-.. image:: {icon}
-   :height: 64px
-   :width: 64px
-
-- :func:`fedmsg.meta.msg2secondary_icon`
-
-  - {secondary_icon}
-
-.. image:: {secondary_icon}
-   :height: 64px
-   :width: 64px
-
-- :func:`fedmsg.meta.msg2usernames`
-
- - ``{usernames}``
-
-- :func:`fedmsg.meta.msg2packages`
-
- - ``{packages}``
-
-- :func:`fedmsg.meta.msg2objects`
-
- - ``{objects}``
-
-"""
+""")
 
 outfile = None
 
@@ -188,15 +182,42 @@ def make_topics_doc(output_dir):
             write(fname, '\n    ' + pprint.pformat(cls.context.msg, indent=2)
                   .replace('\n', '\n    '))
             write(fname)
-            write(fname, metadata_template.format(
+
+            # This is a unique id per entry so we don't collide image tags
+            uid = str(uuid.uuid4())
+            icon_inline = Unspecified
+            secondary_icon_inline = Unspecified
+            if not cls.context.expected_icon is Unspecified:
+                icon_inline = "|%s-icon|" % uid
+            if not cls.context.expected_secondary_icon is Unspecified:
+                secondary_icon_inline = "|%s-secondary_icon|" % uid
+
+            # A bunch of data for the template.
+            kwargs = dict(
                 link=cls.context.expected_link,
                 title=cls.context.expected_title,
                 subtitle=cls.context.expected_subti,
                 usernames=cls.context.expected_usernames,
+                agent=cls.context.expected_agent,
                 packages=cls.context.expected_packages,
                 objects=cls.context.expected_objects,
+                icon_inline=icon_inline,
+                secondary_icon_inline=secondary_icon_inline,
+            )
+
+            def length(value):
+                """ Find longest string so we can pad our tables adequately """
+                if isinstance(value, six.string_types):
+                    return len(value)
+                return len(repr(value))
+            longest = max([length(value) for value in kwargs.values()])
+
+            write(fname, metadata_template.render(
                 icon=cls.context.expected_icon,
                 secondary_icon=cls.context.expected_secondary_icon,
+                Unspecified=Unspecified,
+                longest=longest,
+                **kwargs
             ))
             write(fname)
 


### PR DESCRIPTION
Primarily, include links to datagrepper queries in the docs.

But also enhance the per-testcase template to use mako to handle our icons correctly when they are ``Unspecified``.  Also, replace that ugly nested list with a table that takes up much less room and is much more readable.