### PR TITLE
Change the wording from packager owner to maintainers

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/hotness.py
+++ b/fedmsg_meta_fedora_infrastructure/hotness.py
@@ -104,7 +104,7 @@ class HotnessProcessor(BaseProcessor):
                 'anitya': self._("release-monitoring.org doesn't know what "
                                  "that project is called in Fedora land"),
                 'bugzilla': self._("a bugzilla ticket had already been filed"),
-                'pkgdb': self._("pkgdb says the package owner is not "
+                'pkgdb': self._("pkgdb says the maintainers are not "
                                 "interested in bugs being filed"),
                 'rawhide': self._("no rawhide version of the "
                                   "package could be found yet")

--- a/fedmsg_meta_fedora_infrastructure/tests/hotness.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/hotness.py
@@ -369,7 +369,7 @@ class TestHotnessDropPkgdb(Base):
 
     expected_title = "hotness.update.drop"
     expected_subti = "the-new-hotness saw an update for python-apsw, but " + \
-        "pkgdb says the package owner is not interested in bugs being filed"
+        "pkgdb says the maintainers are not interested in bugs being filed"
     expected_link = "https://release-monitoring.org/project/3772/"
     expected_icon = "https://apps.fedoraproject.org/packages/" + \
         "images/icons/package_128x128.png"


### PR DESCRIPTION
This for two reasons:
- Any maintainer can change the monitoring flag
- We are trying to reduce the concept of ownership for the one of maintainers
and point of contact