### PR TITLE
Various fixes for autocloud.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/autocloud.py
+++ b/fedmsg_meta_fedora_infrastructure/autocloud.py
@@ -31,31 +31,36 @@ class AutoCloudProcessor(BaseProcessor):
     def subtitle(self, msg, **config):
         image_name = msg['msg']['image_name']
         status = msg['msg']['status']
+        release = msg['msg'].get('release')
         if 'autocloud.image' in msg['topic']:
             if status == "queued":
                 tmpl = self._("{image_name} is {status} for testing")
             if status == "running":
-                tmpl = self._("The tests for the {image_name} has "
+                tmpl = self._("The tests for the {image_name} have "
                               "started {status}")
             if status == "aborted":
-                tmpl = self._("The tests for the {image_name} has "
+                tmpl = self._("The tests for the {image_name} have "
                               "been {status}")
             if status == "failed":
                 tmpl = self._("The tests for the {image_name} {status}")
             if status == "success":
-                tmpl = self._("The tests for {image_name} was {status}")
+                tmpl = self._("The tests for {image_name} were a {status}")
+
+            if release:
+                image_name = "%s (%s)" % (image_name, release)
 
             return tmpl.format(image_name=image_name, status=status)
-
-    def link(self, msg, **config):
-        return self.__link__
 
     def secondary_icon(self, msg, **config):
         return self.__icon__
 
     def link(self, msg, **config):
-        image_url = msg['msg']['image_url']
-        return image_url
+        job_id = msg['msg'].get('job_id')
+        if job_id:
+            template = 'https://apps.fedoraproject.org/autocloud/jobs/%s/output'
+            return template % job_id
+        else:
+            return msg['msg']['image_url']
 
     def objects(self, msg, **config):
         status = msg['msg']['status']

--- a/fedmsg_meta_fedora_infrastructure/tests/autocloud.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/autocloud.py
@@ -60,7 +60,7 @@ class TestImageTestRunning(Base):
     in Autocloud app.
     """
     expected_title = "autocloud.image.running"
-    expected_subti = 'The tests for the Fedora-Cloud-Base has started running'
+    expected_subti = 'The tests for the Fedora-Cloud-Base (rawhide) have started running'
     expected_link = 'https://kojipkgs.fedoraproject.org//work/' + \
         'taskstasks/1410/10291410/Fedora-Cloud-Base-22-20150705.i386.qcow2'
     expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/" + \
@@ -79,7 +79,8 @@ class TestImageTestRunning(Base):
             u'status': u'running',
             u'image_url': u'https://kojipkgs.fedoraproject.org//work/'
             'taskstasks/1410/10291410/Fedora-Cloud-Base-22-20150705.i386.qcow2',
-            u'image_name': u'Fedora-Cloud-Base'
+            u'image_name': u'Fedora-Cloud-Base',
+            u'release': 'rawhide',
         }
     }
 
@@ -89,7 +90,7 @@ class TestImageTestAborted(Base):
     in Autocloud app.
     """
     expected_title = "autocloud.image.aborted"
-    expected_subti = 'The tests for the Fedora-Cloud-Base has been aborted'
+    expected_subti = 'The tests for the Fedora-Cloud-Base (rawhide) have been aborted'
     expected_link = 'https://kojipkgs.fedoraproject.org//work/' + \
         'taskstasks/1410/10291410/Fedora-Cloud-Base-22-20150705.i386.qcow2'
     expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/" + \
@@ -108,7 +109,8 @@ class TestImageTestAborted(Base):
             u'status': u'aborted',
             u'image_url': u'https://kojipkgs.fedoraproject.org//work/'
             'taskstasks/1410/10291410/Fedora-Cloud-Base-22-20150705.i386.qcow2',
-            u'image_name': u'Fedora-Cloud-Base'
+            u'image_name': u'Fedora-Cloud-Base',
+            u'release': 'rawhide',
         }
     }
 
@@ -118,9 +120,8 @@ class TestImageTestFailed(Base):
     in Autocloud app.
     """
     expected_title = "autocloud.image.failed"
-    expected_subti = 'The tests for the Fedora-Cloud-Base failed'
-    expected_link = 'https://kojipkgs.fedoraproject.org//work/' + \
-        'taskstasks/1410/10291410/Fedora-Cloud-Base-22-20150705.i386.qcow2'
+    expected_subti = 'The tests for the Fedora-Cloud-Base (23) failed'
+    expected_link = 'https://apps.fedoraproject.org/autocloud/jobs/412/output'
     expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/" + \
         "fedimg.png"
     expected_packages = set([])
@@ -135,9 +136,11 @@ class TestImageTestFailed(Base):
         u'msg': {
             u'buildid': u'10291410',
             u'status': u'failed',
+            u'job_id': 412,
             u'image_url': u'https://kojipkgs.fedoraproject.org//work/'
             'taskstasks/1410/10291410/Fedora-Cloud-Base-22-20150705.i386.qcow2',
-            u'image_name': u'Fedora-Cloud-Base'
+            u'image_name': u'Fedora-Cloud-Base',
+            u'release': u'23',
         }
     }
 
@@ -147,7 +150,7 @@ class TestImageTestSuccess(Base):
     completes in Autocloud app.
     """
     expected_title = "autocloud.image.success"
-    expected_subti = 'The tests for Fedora-Cloud-Base was success'
+    expected_subti = 'The tests for Fedora-Cloud-Base were a success'
     expected_link = 'https://kojipkgs.fedoraproject.org//work/' + \
         'taskstasks/1410/10291410/Fedora-Cloud-Base-22-20150705.i386.qcow2'
     expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/" + \


### PR DESCRIPTION
- Some grammar fixes.
- Removed duplicate definition of the link() method.
- Changed the link() method to return a link to the autocloud results (instead
  of the koji image_url) **if** the job_id is present.  It appears only in
  newer autocloud messages.
- Include the name of the release (rawhide, 23, 22, etc..) in the subject.
  This helps with human parsing of the datagrepper results.