### PR TITLE
Add atomic icon for atomic messages.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/releng.py
+++ b/fedmsg_meta_fedora_infrastructure/releng.py
@@ -26,6 +26,7 @@ class RelengProcessor(BaseProcessor):
     __link__ = "https://git.fedorahosted.org/cgit/releng"
     __docs__ = "https://fedoraproject.org/wiki/ReleaseEngineering"
     __obj__ = "Releng Events"
+    __icon__ = "https://apps.fedoraproject.org/img/icons/atomic.png"
 
     def subtitle(self, msg, **config):
         release = msg['msg']['atomic_raw'].get('release', '')
@@ -43,6 +44,9 @@ class RelengProcessor(BaseProcessor):
 
     def link(self, msg, **config):
         return "https://download.fedoraproject.org/pub/alt/atomic/stable/"
+
+    def secondary_icon(self, msg, **config):
+        return self.__icon__
 
     def objects(self, msg, **config):
         return set([

--- a/fedmsg_meta_fedora_infrastructure/tests/releng.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/releng.py
@@ -42,6 +42,8 @@ class TestTwoWeekAtomicBegin(Base):
     expected_title = "releng.atomic.twoweek.begin"
     expected_subti = "Release engineering scripts started evaluating a " + \
         "new set of builds for a Fedora 22 Atomic Host release"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/atomic.png"
+    expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/atomic.png"
     expected_link = "https://download.fedoraproject.org/pub/alt/atomic/stable/"
     expected_objects = set(['22/atomic_qcow2', '22/atomic_raw'])
 
@@ -82,6 +84,8 @@ class TestTwoWeekAtomicComplete(Base):
 
     expected_title = "releng.atomic.twoweek.complete"
     expected_subti = "A new release of Fedora 22 Atomic Host is ready"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/atomic.png"
+    expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/atomic.png"
     expected_link = "https://download.fedoraproject.org/pub/alt/atomic/stable/"
     expected_objects = set(['22/atomic_qcow2', '22/atomic_raw'])
 


### PR DESCRIPTION
Eventually, when we get more different kinds of releng messages, we'll want to distinguish between atomic and other stuff.. but this works for now.