### PR TITLE
Fix copr links.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/coprs.py
@@ -40,11 +40,11 @@ Status:   {status}
 ID:       {build}
 
 Logs:
-  Build:     https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/{pkg}/build.log.gz
-  Root:      https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/{pkg}/root.log.gz
+  Build:     https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/{build}-{pkg_name}/build.log.gz
+  Root:      https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/{build}-{pkg_name}/root.log.gz
   Copr:      https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/build-{build}.log
-  Mockchain: https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/{pkg}/mockchain.log.gz
-Results:     https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/{pkg}/
+  Mockchain: https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/{build}-{pkg_name}/mockchain.log.gz
+Results:     https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/{build}-{pkg_name}/
 Repodata:    https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chroot}/repodata/
 """
 
@@ -52,7 +52,7 @@ Repodata:    https://copr-be.cloud.fedoraproject.org/results/{owner}/{copr}/{chr
 class CoprsProcessor(BaseProcessor):
     __name__ = "Copr"
     __description__ = "the Cool Other Package Repositories system"
-    __link__ = "https://copr-fe.cloud.fedoraproject.org"
+    __link__ = "https://copr.fedorainfracloud.org"
     __docs__ = "https://fedorahosted.org/copr"
     __obj__ = "Extra Repository Updates"
     __icon__ = "https://apps.fedoraproject.org/img/icons/copr.png"
@@ -74,6 +74,10 @@ class CoprsProcessor(BaseProcessor):
 
             # Zero pad buildid
             kwargs['build'] = '%08d' % (kwargs['build'])
+
+            # Also, extract the name from the NVR.
+            name, version, release = kwargs['pkg'].rsplit('-', 2)
+            kwargs['pkg_name'] = name
 
             details = _long_template.format(**kwargs)
             return details

--- a/fedmsg_meta_fedora_infrastructure/tests/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/coprs.py
@@ -33,11 +33,11 @@ Status:   success
 ID:       00000100
 
 Logs:
-  Build:     https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/mutt-kz-1.5.23.1-1.20150203.git.c8504a8a.fc21/build.log.gz
-  Root:      https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/mutt-kz-1.5.23.1-1.20150203.git.c8504a8a.fc21/root.log.gz
+  Build:     https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/00000100-mutt-kz/build.log.gz
+  Root:      https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/00000100-mutt-kz/root.log.gz
   Copr:      https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/build-00000100.log
-  Mockchain: https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/mutt-kz-1.5.23.1-1.20150203.git.c8504a8a.fc21/mockchain.log.gz
-Results:     https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/mutt-kz-1.5.23.1-1.20150203.git.c8504a8a.fc21/
+  Mockchain: https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/00000100-mutt-kz/mockchain.log.gz
+Results:     https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/00000100-mutt-kz/
 Repodata:    https://copr-be.cloud.fedoraproject.org/results/fatka/mutt-kz/fedora-20-x86_64/repodata/
 """
 
@@ -49,11 +49,11 @@ Status:   failed
 ID:       00080794
 
 Logs:
-  Build:     https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/glib2-2.42.2-1.01.fc21/build.log.gz
-  Root:      https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/glib2-2.42.2-1.01.fc21/root.log.gz
+  Build:     https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/00080794-glib2/build.log.gz
+  Root:      https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/00080794-glib2/root.log.gz
   Copr:      https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/build-00080794.log
-  Mockchain: https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/glib2-2.42.2-1.01.fc21/mockchain.log.gz
-Results:     https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/glib2-2.42.2-1.01.fc21/
+  Mockchain: https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/00080794-glib2/mockchain.log.gz
+Results:     https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/00080794-glib2/
 Repodata:    https://copr-be.cloud.fedoraproject.org/results/brianjmurrell/glib2/fedora-21-x86_64/repodata/
 """
 


### PR DESCRIPTION
Apparently, they changed directory structure on copr-be.

This should address that and fix #363.