### PR TITLE
add openQA processor

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/openqa.py
+++ b/fedmsg_meta_fedora_infrastructure/openqa.py
@@ -1,0 +1,64 @@
+# This file is part of fedmsg.
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Adam Williamson <awilliam@redhat.com>
+
+from fedmsg_meta_fedora_infrastructure import BaseProcessor
+
+class OpenQAProcessor(BaseProcessor):
+    __name__ = "openqa"
+    __description__ = "Distribution-level automated testing"
+    __link__ = "https://openqa.fedoraproject.org"
+    __docs__ = "https://os-autoinst.github.io/openQA/documentation/"
+    __obj__ = "openQA test results"
+    # there is no distro-neutral openQA icon, they use the SUSE geeko
+    #__icon__ = "https://apps.fedoraproject.org/img/icons/taskotron.png"
+
+    def subtitle(self, msg, **config):
+        job = msg['msg'].get('id', '')
+        build = msg['msg'].get('build', '')
+        remain = msg['msg'].get('remaining', '')
+        result = msg['msg'].get('result')
+        msgtmpl = ''
+        if ".stg" in msg['topic']:
+            msgtmpl = "staging "
+
+        if msg['topic'].endswith('job.duplicate'):
+            auto = msg['msg'].get('auto', '')
+            if auto == "0":
+                auto = " manually"
+            if auto == "1":
+                auto = " automatically"
+            msgtmpl += "job {0}{1} duplicated as {2} for {3}"
+            return msgtmpl.format(job, auto, result, build)
+
+        if msg['topic'].endswith('job.restart'):
+            msgtmpl += "job {0} restarted as {1} for {2}"
+            return msgtmpl.format(job, result, build)
+
+        if msg['topic'].endswith('job.done'):
+            msgtmpl += "job {0} completed for {1}, {2} remaining jobs"
+            return msgtmpl.format(job, build, remain)
+
+    def link(self, msg, **config):
+        urltmpl = 'https://openqa.fedoraproject.org/tests/{0}'
+        if '.stg' in msg['topic']:
+            urltmpl = 'https://openqa.stg.fedoraproject.org/tests/{0}'
+        return urltmpl.format(msg['msg'].get('id'))
+
+    def objects(self, msg, **config):
+        return set([msg['msg'].get('build')])

--- a/fedmsg_meta_fedora_infrastructure/tests/__init__.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/__init__.py
@@ -62,6 +62,7 @@ from fedmsg_meta_fedora_infrastructure.tests.taskotron import *
 from fedmsg_meta_fedora_infrastructure.tests.releng import *
 from fedmsg_meta_fedora_infrastructure.tests.mdapi import *
 from fedmsg_meta_fedora_infrastructure.tests.nagios import *
+from fedmsg_meta_fedora_infrastructure.tests.openqa import *
 
 from fedmsg_meta_fedora_infrastructure.tests.base import Base
 

--- a/fedmsg_meta_fedora_infrastructure/tests/openqa.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/openqa.py
@@ -1,0 +1,134 @@
+# This file is part of fedmsg.
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Adam Williamson <awilliam@redhat.com>
+#
+"""Tests for openQA messages."""
+
+import unittest
+from fedmsg.tests.test_meta import Base
+from .common import add_doc
+
+class TestOpenQAJobDuplicateAuto(Base):
+    """openQA emits messages on this topic when a job is duplicated.
+    The 'id' is the job that was duplicated, the 'result' is the new
+    job.
+    """
+    expected_title = "openqa.job.duplicate"
+    expected_subti = ("job 10625 automatically duplicated as 10695 for "
+                      "Fedora-24-20160323.n.0")
+    expected_link = "https://openqa.fedoraproject.org/tests/10625"
+    expected_objects = set(["Fedora-24-20160323.n.0"])
+    msg = {
+        "i": 1,
+        "msg": {
+            "auto": "1",
+            "build": "Fedora-24-20160323.n.0",
+            "id": "10625",
+            "remaining": 39,
+            "result": "10695"
+        },
+        "msg_id": "2016-809a50c2-0829-46b7-beb1-e9cf0ed2ca1a",
+        "source_name": "datanommer",
+        "source_version": "0.6.5",
+        "timestamp": 1458740621.0,
+        "topic": "org.fedoraproject.prod.openqa.job.duplicate"
+    }
+
+
+class TestOpenQAJobDuplicateManual(Base):
+    """openQA emits messages on this topic when a job is duplicated.
+    The 'id' is the job that was duplicated, the 'result' is the new
+    job.
+    """
+    # here we're testing the 'manual' vs. 'auto' difference
+    expected_title = "openqa.job.duplicate"
+    expected_subti = ("job 10625 manually duplicated as 10695 for "
+                      "Fedora-24-20160323.n.0")
+    expected_link = "https://openqa.fedoraproject.org/tests/10625"
+    expected_objects = set(["Fedora-24-20160323.n.0"])
+    msg = {
+        "i": 1,
+        "msg": {
+            "auto": "0",
+            "build": "Fedora-24-20160323.n.0",
+            "id": "10625",
+            "remaining": 39,
+            "result": "10695"
+        },
+        "msg_id": "2016-809a50c2-0829-46b7-beb1-e9cf0ed2ca1a",
+        "source_name": "datanommer",
+        "source_version": "0.6.5",
+        "timestamp": 1458740621.0,
+        "topic": "org.fedoraproject.prod.openqa.job.duplicate"
+    }
+
+
+class TestOpenQAJobRestart(Base):
+    """openQA emits messages on this topic when a job is restarted.
+    The 'id' is the job that was restarted, the 'result' is the id of
+    the new job.
+    """
+    expected_title = "openqa.job.restart"
+    expected_subti = "job 10589 restarted as 10619 for Fedora-24-20160322.4"
+    expected_link = "https://openqa.fedoraproject.org/tests/10589"
+    msg = {
+        "i": 1,
+        "msg": {
+            "build": "Fedora-24-20160322.4",
+            "id": "10589",
+            "remaining": 2,
+            "result": "10619"
+        },
+        "msg_id": "2016-02ec7b3a-ca9d-4844-8361-f46bc883a91d",
+        "source_name": "datanommer",
+        "source_version": "0.6.5",
+        "timestamp": 1458702088.0,
+        "topic": "org.fedoraproject.prod.openqa.job.restart"
+    }
+
+class TestOpenQAJobDoneStaging(Base):
+    """openQA emits messages on this topic when a job completes.
+    'remaining' indicates the number of jobs for the same compose that
+    are either running or waiting to start. 'result' should indicate
+    the result of the job, but at present it is always None due to
+    upstream openQA issues.
+    """
+    expected_title = "openqa.job.done"
+    expected_subti = ("staging job 10826 completed for "
+                      "Fedora-Rawhide-20160323.n.0, 23 remaining jobs")
+    expected_link = "https://openqa.stg.fedoraproject.org/tests/10826"
+    msg = {
+        "i": 1,
+        "msg": {
+            "build": "Fedora-Rawhide-20160323.n.0",
+            "id": "10826",
+            "newbuild": None,
+            "remaining": 23,
+            "result": None,
+        },
+        "msg_id": "2016-fb9690a0-96fd-41e7-a532-0547a4b9229b",
+        "source_name": "datanommer",
+        "source_version": "0.6.5",
+        "timestamp": 1458779794.0,
+        "topic": "org.fedoraproject.stg.openqa.job.done"
+    }
+
+add_doc(locals())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ entry_points = {
         "releng=fedmsg_meta_fedora_infrastructure.releng:RelengProcessor",
         "mdapi=fedmsg_meta_fedora_infrastructure.mdapi:MdapiProcessor",
         "nagios=fedmsg_meta_fedora_infrastructure.nagios:NagiosProcessor",
+        "openqa=fedmsg_meta_fedora_infrastructure.openqa:OpenQAProcessor",
     ]
 }
 


### PR DESCRIPTION
I don't think the tests are running correctly locally (every 'expected' result comes back as an empty string) so @ralphbean said to just send a PR and we'll work it out here. Currently openQA fedmsg's are quite basic so there's only so much processing we can do. Future possibilities include indicating more properties of the job (test suite name, arch, image under test?), result for finished jobs (this is an upstream issue), stuff like that. We don't have a 'who' for openQA events, really, because they're most commonly triggered automatically.