### PR TITLE
Handle new compat issues with copr messages.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/coprs.py
@@ -180,7 +180,7 @@ class TestCoprsBuildFailure(Base):
             "version": "2.42.2-1.01.fc21",
             "build": 80794,
             "owner": "brianjmurrell",
-            "pkg": "glib2-2.42.2-1.01.fc21"
+            "pkg": "glib2",
         }
     }
 


### PR DESCRIPTION
The message format changed (the `pkg` key is now just the package name, not the
whole NVR).

This updates one of the tests to ensure that we handle both the new and the old
format.