### PR TITLE
Special message for Copr automated builds

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/coprs.py
@@ -104,11 +104,19 @@ class CoprsProcessor(BaseProcessor):
         status = _statuses.get(msg['msg'].get('status'), 'unknown')
 
         if 'copr.build.start' in msg['topic']:
-            tmpl = self._("{user} started a new build of the {copr} copr")
+            if user:
+                tmpl = self._("{user} started a new build of the {copr} copr")
+            else:
+                tmpl = self._("Automated build of the {copr} copr has been started")
         elif 'copr.build.end' in msg['topic']:
-            tmpl = self._(
-                "{user}'s {copr} copr build of {pkg} for {chroot} "
-                "finished with '{status}'")
+            if user:
+                tmpl = self._(
+                    "{user}'s {copr} copr build of {pkg} for {chroot} "
+                    "finished with '{status}'")
+            else:
+                tmpl = self._(
+                    "Automated {copr} copr build of {pkg} for {chroot} "
+                    "finished with '{status}'")
         elif 'copr.chroot.start' in msg['topic']:
             tmpl = self._("{user}'s {copr} copr started a new {chroot} chroot")
         elif 'copr.worker.create' in msg['topic']:


### PR DESCRIPTION
Currently, Copr messages for automatic builds are quite ugly, because they contain interpolated None.
Like:
````
None's koschei copr build of koschei-1.6-1.git.16.30a258d.el7 for fedora-23-x86_64 finished with 'success'
````
This PR should change it to:
````
Automated koschei copr build of koschei-1.6-1.git.16.30a258d.el7 for fedora-23-x86_64 finished with 'success'
````