### PR TITLE
Query only for active FAS users.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/fasshim.py
+++ b/fedmsg_meta_fedora_infrastructure/fasshim.py
@@ -125,7 +125,10 @@ def make_fas_cache(**config):
             log.info("Downloading FAS cache for %s*" % key)
             response = fasclient.send_request(
                 '/user/list',
-                req_params={'search': '%s*' % key},
+                req_params={
+                    'search': '%s*' % key,
+                    'status': 'active',
+                },
                 auth=True)
         except fedora.client.ServerError as e:
             log.warning("Failed to download fas cache for %s %r" % (key, e))


### PR DESCRIPTION
This is a follow-on to #383 that takes advantage of fedora-infra/fas#162.

It seems that the code from #383 fails now given that spammers have bloated our
FAS db.  Searching just for `'a*'` times out/fails.

By introducing `'status': 'active',` here, it gets things working again.
Querying for just `'a*'` took about 3.5 minutes on a local test at the time of
writing.
