### PR TITLE
Fix something we faced in FMN stg, copr messages where the agent is None

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/conglomerators/copr/copr.py
+++ b/fedmsg_meta_fedora_infrastructure/conglomerators/copr/copr.py
@@ -9,7 +9,7 @@ class AbstractCoprConglomerator(fedmsg.meta.base.BaseConglomerator):
     def merge(self, constituents, subject, **config):
         ms = constituents  # shorthand
 
-        agents = set([m['msg']['user'] for m in ms])
+        agents = set([m['msg']['user'] for m in ms if m['msg']['user']])
         coprs = set([m['msg']['copr'] for m in ms])
         count = len([1 for m in ms
                       if m['topic'].endswith('copr.build.start')])


### PR DESCRIPTION
Having None in the list of agent made the call to self.list_to_series
fail.
With this, we should avoid the issue