### PR TITLE
Adjust after diff access levels in pagure

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/pagure.py
@@ -284,10 +284,27 @@ class PagureProcessor(BaseProcessor):
             return tmpl.format(user=user, project=project, fields=fields)
         elif 'pagure.project.user.added' in msg['topic']:
             new_user = msg['msg']['new_user']
+            access = msg['msg'].get('access')
+            if access:
+                tmpl = self._(
+                    '{user} added "{new_user}" to project {project} '
+                    'with {access} access'
+                )
+            else:
+                tmpl = self._(
+                    '{user} added "{new_user}" to project {project}'
+                )
+            return tmpl.format(
+                user=user, project=project, new_user=new_user, access=access)
+        elif 'pagure.project.user.access.updated' in msg['topic']:
+            new_user = msg['msg']['new_user']
+            new_access = msg['msg']['new_access']
             tmpl = self._(
-                '{user} added "{new_user}" to project {project}'
+                '{user} updated access of "{new_user}" to {new_access} '
+                'in project {project}'
             )
-            return tmpl.format(user=user, project=project, new_user=new_user)
+            return tmpl.format(
+                user=user, project=project, new_user=new_user, new_access=new_access)
         elif 'pagure.project.tag.removed' in msg['topic']:
             tags = msg['msg']['tags']
             tags = fedmsg.meta.base.BaseConglomerator.list_to_series(tags)

--- a/fedmsg_meta_fedora_infrastructure/tests/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pagure.py
@@ -777,6 +777,51 @@ class TestProjectEdit(Base):
     }
 
 
+class TestProjectUserAccessUpdated(Base):
+    """ These messages are published when a someone updates someones rights on a
+    project on `pagure <https://pagure.io>`_.
+    """
+    expected_title = "pagure.project.user.access.updated"
+    expected_subti = 'pingou updated access of "ralph" to commit in ' + \
+        'project foo'
+    expected_link = "https://pagure.io/foo"
+    expected_icon = "https://apps.fedoraproject.org/packages/" + \
+        "images/icons/package_128x128.png"
+    expected_secondary_icon = "https://seccdn.libravatar.org/avatar/" + \
+        "01fe73d687f4db328da1183f2a1b5b22962ca9d9c50f0728aafeac974856311c" + \
+        "?s=64&d=retro"
+    expected_packages = set([])
+    expected_usernames = set(['pingou'])
+    expected_objects = set(['project/foo'])
+    msg = {
+      "i": 4,
+      "timestamp": 1427455518,
+      "msg_id": "2015-b3c2e568-259a-4b1f-9ecc-79493b89687a",
+      "topic": "io.pagure.dev.pagure.project.user.access.updated",
+      "msg": {
+        "new_user": "ralph",
+        "new_access": "commit",
+        "project": {
+          "description": "bar",
+          "parent": None,
+          "project_docs": False,
+          "issue_tracker": True,
+          "user": {
+            "fullname": "Pierre-YvesChibon",
+            "emails": [
+              "pingou@fedoraproject.org"
+            ],
+            "name": "pingou"
+          },
+          "date_created": "1427441537",
+          "id": 7,
+          "name": "foo"
+        },
+        "agent": "pingou"
+      }
+    }
+
+
 class TestProjectUserAdded(Base):
     """ These messages are published when a someone gave some rights on a
     project on `pagure <https://pagure.io>`_.

--- a/fedmsg_meta_fedora_infrastructure/tests/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pagure.py
@@ -17,7 +17,7 @@
 #
 # Authors:  Pierre-Yves Chibon <pingou@pingoured.fr>
 #
-""" Tests for anitya messages """
+""" Tests for pagure messages """
 
 import unittest
 

--- a/fedmsg_meta_fedora_infrastructure/tests/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pagure.py
@@ -778,6 +778,50 @@ class TestProjectEdit(Base):
 
 
 class TestProjectUserAdded(Base):
+    """ These messages are published when a someone gave some rights on a
+    project on `pagure <https://pagure.io>`_.
+    """
+    expected_title = "pagure.project.user.added"
+    expected_subti = 'pingou added "ralph" to project foo with admin access'
+    expected_link = "https://pagure.io/foo"
+    expected_icon = "https://apps.fedoraproject.org/packages/" + \
+        "images/icons/package_128x128.png"
+    expected_secondary_icon = "https://seccdn.libravatar.org/avatar/" + \
+        "01fe73d687f4db328da1183f2a1b5b22962ca9d9c50f0728aafeac974856311c" + \
+        "?s=64&d=retro"
+    expected_packages = set([])
+    expected_usernames = set(['pingou'])
+    expected_objects = set(['project/foo'])
+    msg = {
+      "i": 4,
+      "timestamp": 1427455518,
+      "msg_id": "2015-b3c2e568-259a-4b1f-9ecc-79493b89687a",
+      "topic": "io.pagure.dev.pagure.project.user.added",
+      "msg": {
+        "new_user": "ralph",
+        "access": "admin",
+        "project": {
+          "description": "bar",
+          "parent": None,
+          "project_docs": False,
+          "issue_tracker": True,
+          "user": {
+            "fullname": "Pierre-YvesChibon",
+            "emails": [
+              "pingou@fedoraproject.org"
+            ],
+            "name": "pingou"
+          },
+          "date_created": "1427441537",
+          "id": 7,
+          "name": "foo"
+        },
+        "agent": "pingou"
+      }
+    }
+
+
+class LegacyTestProjectUserAdded(Base):
     """ These messages are published when a someone gave admins rights on a
     project on `pagure <https://pagure.io>`_.
     """


### PR DESCRIPTION
There are a couple of changes in the way pagure will send info via fedmsg after [this](https://pagure.io/pagure/pull-request/1177). For groups, i will add them in a diff PR. Also, i have just ran the tests, i don't know if there is any other way to test this locally.