### PR TITLE
When copr repo belongs to a group, alter the link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 # Someday, soon.
 # - "3.2"
 install:
+ - pip install --upgrade setuptools pip
  - python setup.py install
  - pip install arrow
 script: python setup.py test

--- a/fedmsg_meta_fedora_infrastructure/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/coprs.py
@@ -129,6 +129,9 @@ class CoprsProcessor(BaseProcessor):
 
     def link(self, msg, **config):
         user = msg['msg'].get('owner', msg['msg'].get('user'))
+        if user.startswith('@'):
+            # It's a group
+            user = user.replace('@', 'g/')
         copr = msg['msg'].get('copr')
         chroot = msg['msg'].get('chroot', None)
         build = msg['msg'].get('build')

--- a/fedmsg_meta_fedora_infrastructure/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/coprs.py
@@ -129,7 +129,7 @@ class CoprsProcessor(BaseProcessor):
 
     def link(self, msg, **config):
         user = msg['msg'].get('owner', msg['msg'].get('user'))
-        if user.startswith('@'):
+        if user and user.startswith('@'):
             # It's a group
             user = user.replace('@', 'g/')
         copr = msg['msg'].get('copr')

--- a/fedmsg_meta_fedora_infrastructure/tests/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/coprs.py
@@ -253,6 +253,10 @@ class TestCoprsGroupLink(Base):
     """ `Copr <https://fedorahosted.org/copr/>`_ publishes these messages
     when a build has completed.  This is an example of a group repo.
     """
+    expected_title = "copr.build.end"
+    expected_subti = (
+        "churchyard's python26 copr build of python26-2.6.9-1.fc26 for "
+        "fedora-23-i386 finished with 'failed'")
     expected_link = ("https://copr.fedoraproject.org/coprs/"
                      "g/python/python26/build/450811/")
 

--- a/fedmsg_meta_fedora_infrastructure/tests/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/coprs.py
@@ -249,6 +249,39 @@ class TestCoprsWorkerCreate(Base):
     }
 
 
+class TestCoprsGroupLink(Base):
+    """ `Copr <https://fedorahosted.org/copr/>`_ publishes these messages
+    when a build has completed.  This is an example of a group repo.
+    """
+    expected_link = ("https://copr.fedoraproject.org/coprs/"
+                     "g/python/python26/build/450811/")
+
+    {
+        u'source_name': u'datanommer',
+        u'i': 3,
+        u'timestamp': 1473355790.0,
+        u'msg_id': u'2016-31e1e282-c176-4a9e-94bc-e4ae34536d47',
+        u'topic': u'org.fedoraproject.prod.copr.build.end',
+        u'source_version': u'0.6.5',
+        u'msg': {
+            u'status': 0,
+            u'what': u'build end: user:churchyard copr:python26 build:450811'
+            '  pkg: python26  version: 2.6.9-1.fc26 ip:172.25.83.110'
+            '  pid:7513 status:0',
+            u'chroot': u'fedora-23-i386',
+            u'ip': u'172.25.83.110',
+            u'user': u'churchyard',
+            u'who': u'backend.worker-6023-PC',
+            u'pid': 7513,
+            u'copr': u'python26',
+            u'version': u'2.6.9-1.fc26',
+            u'build': 450811,
+            u'owner': u'@python',
+            u'pkg': u'python26',
+        },
+    }
+
+
 add_doc(locals())
 
 if __name__ == '__main__':

--- a/fedmsg_meta_fedora_infrastructure/tests/coprs.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/coprs.py
@@ -256,7 +256,7 @@ class TestCoprsGroupLink(Base):
     expected_link = ("https://copr.fedoraproject.org/coprs/"
                      "g/python/python26/build/450811/")
 
-    {
+    msg = {
         u'source_name': u'datanommer',
         u'i': 3,
         u'timestamp': 1473355790.0,


### PR DESCRIPTION
Fixes https://github.com/fedora-infra/fmn/issues/134