### PR TITLE
Handle new koji rpm.sign message format.

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/buildsys.py
@@ -774,11 +774,9 @@ class TestKojiPackageListChange(Base):
     }
 
 
-class TestKojiRPMSign(Base):
-    """ Koji emits these messages a package is signed with GPG.
-
-    For more information, see the `sigul project
-    <https://fedorahosted.org/sigul/>`_.
+class LegacyTestKojiRPMSign(Base):
+    """ The format of the rpm.sign message changed in 2016:
+    https://pagure.io/koji/pull-request/188
     """
     expected_title = "buildsys.rpm.sign"
     expected_subti = "Koji build " + \
@@ -827,6 +825,60 @@ class TestKojiRPMSign(Base):
         }
     }
 
+
+class TestKojiRPMSign(Base):
+    """ Koji emits these messages a package is signed with GPG.
+
+    For more information, see the `sigul project
+    <https://fedorahosted.org/sigul/>`_.
+    """
+    expected_title = "buildsys.rpm.sign"
+    expected_subti = "Koji build " + \
+        "gstreamer1-plugins-base-devel-1.4.5-1.fc21.i686.rpm signed " + \
+        "with sigkey 'ab845621'"
+    expected_icon = ("https://fedoraproject.org/w/uploads/2/20/"
+                     "Artwork_DesignService_koji-icon-48.png")
+    expected_link = ("http://koji.fedoraproject.org/koji/"
+                     "buildinfo?buildID=607658")
+    expected_secondary_icon = expected_icon
+    expected_packages = set(["gstreamer1-plugins-base-devel"])
+    expected_usernames = set([])
+    expected_objects = set([
+        'signatures/gstreamer1-plugins-base-devel',
+    ])
+
+    msg = {
+        "username": "apache",
+        "i": 15,
+        "timestamp": 1422465977,
+        "msg_id": "2015-271fd050-3198-46f8-b0b1-4bcf6e70bdd0",
+        "crypto": "x509",
+        "topic": "org.fedoraproject.prod.buildsys.rpm.sign",
+        "msg": {
+            "build": {
+                "id": 607658,
+                # ...
+            },
+            "rpm": {
+                "build_id": 607658,
+                "name": "gstreamer1-plugins-base-devel",
+                "buildroot_id": 2877398,
+                "buildtime": 1422465286,
+                "id": 5928874,
+                "epoch": None,
+                "version": "1.4.5",
+                "arch": "i686",
+                "release": "1.fc21",
+                "external_repo_id": 0,
+                "payloadhash": "05bc945666248817e0b5346f811bbac0",
+                "external_repo_name": "INTERNAL",
+                "size": 266720
+            },
+            "sigkey": "ab845621",
+            "sighash": "8f84058e6bbcae89701271e8b0c43d1d",
+            "instance": "primary"
+        }
+    }
 
 
 add_doc(locals())


### PR DESCRIPTION
There's a change coming in upstream koji that changes the format of the `rpm.sign` message:  https://pagure.io/koji/pull-request/188

This changes should keep us working on both the old and the new format.
