### PR TITLE
Update wording of Pagure messages to match Github messages

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/pagure.py
@@ -353,22 +353,20 @@ class PagureProcessor(BaseProcessor):
         elif 'pagure.project.forked' in msg['topic']:
             old_project = msg['msg']['project']['parent']['name']
             tmpl = self._(
-                '{user} forked project "{old_project}" to "{project}"'
+                '{user} forked {old_project} to {project}'
             )
             return tmpl.format(
                 user=user, old_project=old_project, project=project)
         elif 'pagure.pull-request.comment.added' in msg['topic']:
             prid = msg['msg']['pullrequest']['id']
             tmpl = self._(
-                '{user} commented on pull-request#{id} of project '
-                '"{project}"'
+                '{user} commented on PR #{id} on {project}'
             )
             return tmpl.format(user=user, id=prid, project=project)
         elif 'pagure.pull-request.comment.edited' in msg['topic']:
             prid = msg['msg']['pullrequest']['id']
             tmpl = self._(
-                '{user} edited a comment on pull-request#{id} of project '
-                '"{project}"'
+                '{user} edited a comment on PR #{id} on {project}'
             )
             return tmpl.format(user=user, id=prid, project=project)
         elif 'pagure.pull-request.closed' in msg['topic']:
@@ -376,21 +374,19 @@ class PagureProcessor(BaseProcessor):
             merged = msg['msg']['merged']
             if merged:
                 tmpl = self._(
-                    '{user} merged pull-request#{id} of project '
-                    '"{project}"'
+                    '{user} merged pull request #{id} on {project}'
                 )
             else:
                 tmpl = self._(
-                    '{user} closed (without merging) pull-request#{id} '
-                    'of project "{project}"'
+                    '{user} closed (without merging) pull request #{id} '
+                    'on {project}'
                 )
             return tmpl.format(user=user, id=prid, project=project)
         elif 'pagure.pull-request.new' in msg['topic']:
             prid = msg['msg']['pullrequest']['id']
             title = msg['msg']['pullrequest']['title']
             tmpl = self._(
-                '{user} opened pull-request#{id}: "{title}" on '
-                'project "{project}"'
+                '{user} opened pull request #{id} on {project}: {title}'
             )
             return tmpl.format(
                 user=user, id=prid, project=project, title=title)

--- a/fedmsg_meta_fedora_infrastructure/tests/conglomerate/pagure/test_pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/conglomerate/pagure/test_pagure.py
@@ -31,8 +31,8 @@ class TestPagureConglomeratorByIssueAndPR(
             'packages': set([]),
             'secondary_icon': 'https://seccdn.libravatar.org/avatar/1216fff466c9dbb6ce85ac95bf8f45b9e19421af97de67945852722b899a34ee?s=64&d=retro',
             'start_time': 1458307490.0,
-            'subjective': u'bonnegent forked project "pagure" to "fork/bonnegent/pagure"',
-            'subtitle': u'bonnegent forked project "pagure" to "fork/bonnegent/pagure"',
+            'subjective': u'bonnegent forked pagure to fork/bonnegent/pagure',
+            'subtitle': u'bonnegent forked pagure to fork/bonnegent/pagure',
             'timestamp': 1458307490.0,
             'topics': set(['io.pagure.prod.pagure.project.forked']),
             'usernames': set(['bonnegent'])
@@ -149,8 +149,8 @@ class TestPagureConglomeratorByIssueAndPR(
             'packages': set([]),
             'secondary_icon': 'https://seccdn.libravatar.org/avatar/01fe73d687f4db328da1183f2a1b5b22962ca9d9c50f0728aafeac974856311c?s=64&d=retro',
             'start_time': 1458297187.0,
-            'subjective': u'pingou commented on pull-request#848 of project "pagure"',
-            'subtitle': u'pingou commented on pull-request#848 of project "pagure"',
+            'subjective': u'pingou commented on PR #848 on pagure',
+            'subtitle': u'pingou commented on PR #848 on pagure',
             'timestamp': 1458297187.0,
             'topics': set(['io.pagure.prod.pagure.pull-request.comment.added']),
             'usernames': set(['pingou'])}

--- a/fedmsg_meta_fedora_infrastructure/tests/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pagure.py
@@ -1337,7 +1337,7 @@ class TestProjectForked(Base):
     project on `pagure <https://pagure.io>`_.
     """
     expected_title = "pagure.project.forked"
-    expected_subti = 'pingou forked project "fedmsg" to "fork/pingou/fedmsg"'
+    expected_subti = 'pingou forked fedmsg to fork/pingou/fedmsg'
     expected_link = "https://pagure.io/fork/pingou/fedmsg"
     expected_icon = "https://apps.fedoraproject.org/packages/" + \
         "images/icons/package_128x128.png"
@@ -1394,8 +1394,7 @@ class TestNewPullRequestComment(Base):
     pull-request of a project on `pagure <https://pagure.io>`_.
     """
     expected_title = "pagure.pull-request.comment.added"
-    expected_subti = 'pingou commented on pull-request#6 of '\
-        'project "test"'
+    expected_subti = 'pingou commented on PR #6 on test'
     expected_link = "https://pagure.io/test/pull-request/6#comment-16"
     expected_icon = "https://apps.fedoraproject.org/packages/" + \
         "images/icons/package_128x128.png"
@@ -1504,8 +1503,7 @@ class TestEditPullRequestComment(Base):
     pull-request of a project on `pagure <https://pagure.io>`_.
     """
     expected_title = "pagure.pull-request.comment.edited"
-    expected_subti = 'lmacken edited a comment on pull-request#31 of '\
-        'project "mdapi"'
+    expected_subti = 'lmacken edited a comment on PR #31 on mdapi'
     expected_link = "https://pagure.io/mdapi/pull-request/31#comment-2922"
     expected_icon = "https://apps.fedoraproject.org/packages/" + \
         "images/icons/package_128x128.png"
@@ -1651,8 +1649,7 @@ class TestNewPullRequestclosed(Base):
     of a project on `pagure <https://pagure.io>`_.
     """
     expected_title = "pagure.pull-request.closed"
-    expected_subti = 'pingou closed (without merging) pull-request#6 '\
-        'of project "test"'
+    expected_subti = 'pingou closed (without merging) pull request #6 on test'
     expected_link = "https://pagure.io/test/pull-request/6"
     expected_icon = "https://apps.fedoraproject.org/packages/" + \
         "images/icons/package_128x128.png"
@@ -1762,7 +1759,7 @@ class TestNewPullRequestMerged(Base):
     of a project on `pagure <https://pagure.io>`_.
     """
     expected_title = "pagure.pull-request.closed"
-    expected_subti = 'pingou merged pull-request#7 of project "test"'
+    expected_subti = 'pingou merged pull request #7 on test'
     expected_link = "https://pagure.io/test/pull-request/7"
     expected_icon = "https://apps.fedoraproject.org/packages/" + \
         "images/icons/package_128x128.png"
@@ -1872,8 +1869,8 @@ class TestNewPullRequestNew(Base):
     on a project on `pagure <https://pagure.io>`_.
     """
     expected_title = "pagure.pull-request.new"
-    expected_subti = 'pingou opened pull-request#21: "Improve loading '\
-        'speed" on project "test"'
+    expected_subti = 'pingou opened pull request #21 on test: Improve loading '\
+        'speed'
     expected_link = "https://pagure.io/test/pull-request/21"
     expected_icon = "https://apps.fedoraproject.org/packages/" + \
         "images/icons/package_128x128.png"


### PR DESCRIPTION
The main aim is consistency between the Pagure and Github messages, but this also has the side effect of tidying up some nits in the wording of the Pagure messages:

* "Pull request" is two words, not hyphenated, and the identifier shouldn't run together with the phrase "pull request", so: `opened pull request #123` instead of `opened pull-request#123`
* Changed `project "fm-orchestrator"` to just `fm-orchestrator`, since the word `project` is superfluous. That makes it is a bit more compact and easier to scan in a list.
* Moved the pull request subject to the end, with the project before it. Again, makes it easier to read in a list of e-mail subjects.

The latter point is particularly important when some pull request submitters tend to write very long subjects, so for example this mail I received:

```
jkaluza opened pull-request#454: "Retry communication with PDC on RuntimeError exception and increase the timeout to 120 seconds" on project "fm-orchestrator"
```

would instead be:

```
jkaluza opened pull request #454 on fm-orchestrator: Retry communication with PDC on RuntimeError exception and increase the timeout to 120 seconds
```