### PR TITLE
Adjust the scm links to the deployment of pagure over dist-git

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/__init__.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/__init__.py
@@ -316,7 +316,7 @@ class TestPkgdb2BrCreateLegacy(Base):
         "67fc36d5974ea45ec922a650dc117d83acf0a1f646cd17ba80e9e0fe6e2ed164" + \
         "?s=64&d=retro"
     expected_link = \
-        "https://src.fedoraproject.org/cgit/valgrind.git/log/?h=master"
+        "https://src.fedoraproject.org/rpms/valgrind/commits/master"
     expected_usernames = set(['limburgher'])
     expected_packages = set(['valgrind'])
     expected_objects = set(['valgrind/__git__'])
@@ -344,7 +344,7 @@ class TestPkgdb2BrCreate(Base):
     expected_subti = \
         "limburgher created branch 'master' for the 'valgrind' package"
     expected_link = \
-        "https://src.fedoraproject.org/cgit/valgrind.git/log/?h=master"
+        "https://src.fedoraproject.org/rpms/valgrind/commits/master"
     expected_secondary_icon = "https://seccdn.libravatar.org/avatar/" + \
         "67fc36d5974ea45ec922a650dc117d83acf0a1f646cd17ba80e9e0fe6e2ed164" + \
         "?s=64&d=retro"

--- a/fedmsg_meta_fedora_infrastructure/tests/example.patch
+++ b/fedmsg_meta_fedora_infrastructure/tests/example.patch
@@ -1,11 +1,10 @@
 From 66abdea4014eb2f0745fc38f86e20c7d7009237e Mon Sep 17 00:00:00 2001
 From: Ralph Bean <rbean@redhat.com>
-Date: Mon, 8 Oct 2012 13:25:49 -0400
+Date: Oct 08 2012 17:25:49 +0000
 Subject: Try removing requirement on python-bunch.
 
+
 ---
- datanommer.spec | 10 ++++------
- 1 file changed, 4 insertions(+), 6 deletions(-)
 
 diff --git a/datanommer.spec b/datanommer.spec
 index c34b795..1db1d0a 100644
@@ -41,6 +40,4 @@ index c34b795..1db1d0a 100644
  * Thu Oct 04 2012 Ralph Bean <rbean@redhat.com> - 0.1.8-1
  - More flexible database field types.
  * Fri Sep 28 2012 Ralph Bean <rbean@redhat.com> - 0.1.7-1
--- 
-cgit v1.1
 

--- a/fedmsg_meta_fedora_infrastructure/tests/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/scm.py
@@ -48,8 +48,8 @@ class TestGitReceiveLegacyModified(Base):
     expected_packages = set(['datanommer'])
     expected_usernames = set()
     expected_objects = set(['datanommer/datanommer.spec'])
-    expected_link = ("https://src.fedoraproject.org/cgit/datanommer.git/commit"
-                     "/?h=master&id=66abdea4014eb2f0745fc38f86e20c7d7009237e")
+    expected_link = ("https://src.fedoraproject.org/rpms/datanommer/c/"
+                     "66abdea4014eb2f0745fc38f86e20c7d7009237e?branch=master")
 
     msg = {
         "i": 1,
@@ -89,9 +89,9 @@ class TestSCMSuperLegacy(Base):
     expected_title = "git.receive.valgrind.master"
     expected_subti = 'mjw pushed to valgrind (master).  ' + \
         '"Clear CFLAGS CXXFLAGS LDFLAGS. (..more)"'
-    expected_link = "https://src.fedoraproject.org/cgit/" + \
-        "valgrind.git/commit/" + \
-        "?h=master&id=7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1"
+    expected_link = "https://src.fedoraproject.org/rpms/" + \
+        "valgrind/c/" + \
+        "7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1?branch=master"
     expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
     expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
         "0f32874b1ae3083205c874c83cd2d21715c89b8645483f353e90ae499c67c944"
@@ -140,9 +140,9 @@ class TestSCMLegacy(Base):
     expected_title = "git.receive.valgrind.master"
     expected_subti = 'mjw pushed to valgrind (master).  ' + \
         '"Clear CFLAGS CXXFLAGS LDFLAGS. (..more)"'
-    expected_link = "https://src.fedoraproject.org/cgit/" + \
-        "valgrind.git/commit/" + \
-        "?h=master&id=7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1"
+    expected_link = "https://src.fedoraproject.org/rpms/" + \
+        "valgrind/c/" + \
+        "7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1?branch=master"
     expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
     expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
         "0f32874b1ae3083205c874c83cd2d21715c89b8645483f353e90ae499c67c944"
@@ -193,9 +193,9 @@ class TestSCM(Base):
     expected_title = "git.receive"
     expected_subti = 'mjw pushed to valgrind (master).  ' + \
         '"Clear CFLAGS CXXFLAGS LDFLAGS. (..more)"'
-    expected_link = "https://src.fedoraproject.org/cgit/" + \
-        "valgrind.git/commit/" + \
-        "?h=master&id=7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1"
+    expected_link = "https://src.fedoraproject.org/rpms/" + \
+        "valgrind/c/" + \
+        "7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1?branch=master"
     expected_long_form = "This commit already existed in another branch."
     expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
     expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
@@ -248,9 +248,9 @@ class TestSCMSingleLine(Base):
     expected_title = "git.receive"
     expected_subti = 'spot pushed to ember (master).  ' + \
         '"another missing patch? ridiculous."'
-    expected_link = "https://src.fedoraproject.org/cgit/" + \
-        "ember.git/commit/" + \
-        "?h=master&id=aa2df80f3d8dd217c7cbfe2d3451190028f3fe14"
+    expected_link = "https://src.fedoraproject.org/rpms/" + \
+        "ember/c/" + \
+        "aa2df80f3d8dd217c7cbfe2d3451190028f3fe14?branch=master"
     expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
     expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
         "1e232310ef80ec8b34b0bc216864efd0d837f419e6988997cda8e98a28be48dd"


### PR DESCRIPTION
While doing so fix retrieving the entire patch of a commit from pagure
as we used to do it from cgit.

Fixes https://pagure.io/fedora-infrastructure/issue/6204

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>