### PR TITLE
Seems we are now getting messages with broken branch numbers

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/compose.py
+++ b/fedmsg_meta_fedora_infrastructure/compose.py
@@ -128,6 +128,9 @@ class ComposeProcessor(BaseProcessor):
                 except TypeError:
                     base = "https://dl.fedoraproject.org/pub/" + \
                         "fedora/linux/development"
+                except ValueError:
+                    base = "https://github.com/fedora-infra/" + \
+                        "fedmsg_meta_fedora_infrastructure/?WHOKNOWS&"
                 else:
                     base = "https://dl.fedoraproject.org/pub/" + \
                         "fedora/linux/releases"


### PR DESCRIPTION
exceptions.ValueError: invalid literal for int() with base 10: 'Modular-27'

This is a "fix" that will make people aware to fix fedmsg-meta.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>