### PR TITLE
Add support for fedmsg messages of pagure over dist-git

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/pagure.py
@@ -81,6 +81,7 @@ class PagureProcessor(BaseProcessor):
     __name__ = "pagure"
     __description__ = "Pagure forge"
     __link__ = "https://pagure.io"
+    __stg_link__ = "https://stg.pagure.io"
     __docs__ = "https://pagure.io/pagure"
     __obj__ = "Pagure forge"
     __icon__ = ("https://apps.fedoraproject.org/packages/"
@@ -103,7 +104,9 @@ class PagureProcessor(BaseProcessor):
             except KeyError:
                 project = "(unknown)"
 
-        base_url = "https://pagure.io"
+        base_url = self.__link__
+        if '.stg.' in msg['topic']:
+            base_url = self.__stg_link__
 
         tmpl = '{base_url}/{project}'
         if 'pagure.issue' in msg['topic']:
@@ -473,3 +476,23 @@ class PagureProcessor(BaseProcessor):
             ])
 
         return set([])
+
+
+class DistGitPagureProcessor(PagureProcessor):
+    topic_prefix_re = 'org\\.fedoraproject\\.(dev|stg|prod)'
+
+    __name__ = "pagure"
+    __description__ = "Pagure over Dist-git"
+    __link__ = "https://src.fedoraproject.org"
+    __stg_link__ = "https://src.stg.fedoraproject.org"
+    __docs__ = "https://src.fedoraproject.org"
+    __obj__ = "Pagure over Dist-git"
+    __icon__ = ("https://apps.fedoraproject.org/packages/"
+                "images/icons/package_128x128.png")
+
+    conglomerators = [
+        pagure_conglomerator.ByPR,
+        pagure_conglomerator.ByIssue,
+        pagure_conglomerator.ByNewStyleCommit,
+        pagure_conglomerator.ByOldStyleCommit,
+    ]

--- a/fedmsg_meta_fedora_infrastructure/tests/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pagure.py
@@ -2477,6 +2477,204 @@ class TestIssueCommentEdit(Base):
     }
 
 
+class TestNewProjectDistGit(Base):
+    """ These messages are published when a new project is created on
+    `dist-git <https://src.fedoraproject.org>`_.
+    """
+    expected_title = "pagure.project.new"
+    expected_subti = 'mprahl created a new project "rpms/arachne-pnr"'
+    expected_link = "https://src.fedoraproject.org/rpms/arachne-pnr"
+    expected_icon = "https://apps.fedoraproject.org/packages/" + \
+        "images/icons/package_128x128.png"
+    expected_secondary_icon = "https://seccdn.libravatar.org/avatar/" + \
+        "c67eaa686cc9827d78bcce9aef84e26a944b8fccdb8741c7842dcf561808a7e8" + \
+        "?s=64&d=retro"
+    expected_packages = set([])
+    expected_usernames = set(['mprahl'])
+    expected_objects = set(['project/rpms/arachne-pnr'])
+    msg = {
+          "username": "pagure",
+          "source_name": "datanommer",
+          "i": 1,
+          "timestamp": 1505394473.0,
+          "msg_id": "2017-d5a8da88-bcdc-402b-863a-1545016f2f2c",
+          "crypto": "x509",
+          "topic": "org.fedoraproject.prod.pagure.project.new",
+          "headers": {},
+          "source_version": "0.8.1",
+          "msg": {
+            "project": {
+              "custom_keys": [],
+              "description": "The arachne-pnr package",
+              "parent": None,
+              "date_modified": "1505394470",
+              "access_users": {
+                "admin": [],
+                "commit": [],
+                "ticket": [],
+                "owner": [
+                  "mprahl"
+                ]
+              },
+              "namespace": "rpms",
+              "priorities": {},
+              "id": 22781,
+              "access_groups": {
+                "admin": [],
+                "commit": [],
+                "ticket": []
+              },
+              "milestones": {},
+              "user": {
+                "fullname": "Matt Prahl",
+                "name": "mprahl"
+              },
+              "date_created": "1505394470",
+              "fullname": "rpms/arachne-pnr",
+              "settings": {
+                "issues_default_to_private": False,
+                "Minimum_score_to_merge_pull-request": -1,
+                "pull_request_access_only": False,
+                "Web-hooks": None,
+                "fedmsg_notifications": True,
+                "always_merge": False,
+                "project_documentation": False,
+                "Enforce_signed-off_commits_in_pull-request": False,
+                "pull_requests": True,
+                "Only_assignee_can_merge_pull-request": False,
+                "issue_tracker": True
+              },
+              "close_status": [],
+              "tags": [],
+              "name": "arachne-pnr"
+            },
+            "agent": "mprahl"
+          }
+        }
+
+
+class TestProjectForkedDistGit(Base):
+    """ These messages are published when a someone forks a project on
+    `dist-git <https://src.fedoraproject.org>`_.
+    """
+    expected_title = "pagure.project.forked"
+    expected_subti = 'puiterwijk forked ipsilon to fork/puiterwijk/rpms/ipsilon'
+    expected_link = "https://src.stg.fedoraproject.org/fork/puiterwijk/rpms/ipsilon"
+    expected_icon = "https://apps.fedoraproject.org/packages/" + \
+        "images/icons/package_128x128.png"
+    expected_secondary_icon = "https://seccdn.libravatar.org/avatar/" + \
+        "983782d075ab4e1fb02a7e7c7ca4d7096f6769bc9fe51b50e80eb012ddebc9ce" + \
+        "?s=64&d=retro"
+    expected_packages = set([])
+    expected_usernames = set(['puiterwijk'])
+    expected_objects = set(['project/fork/puiterwijk/rpms/ipsilon'])
+    msg = {
+          "username": None,
+          "source_name": "datanommer",
+          "i": 1,
+          "timestamp": 1502052155.0,
+          "msg_id": "2017-a992188d-62c4-4c53-aea6-67a82a355b9b",
+          "crypto": None,
+          "topic": "org.fedoraproject.stg.pagure.project.forked",
+          "headers": {},
+          "source_version": "0.7.0",
+          "msg": {
+            "project": {
+              "custom_keys": [],
+              "description": "The ipsilon rpms",
+              "parent": {
+                "custom_keys": [],
+                "description": "The ipsilon rpms",
+                "parent": None,
+                "date_modified": "1501275113",
+                "access_users": {
+                  "admin": [],
+                  "commit": [
+                    "simo"
+                  ],
+                  "ticket": [],
+                  "owner": [
+                    "puiterwijk"
+                  ]
+                },
+                "namespace": "rpms",
+                "priorities": {},
+                "id": 6398,
+                "access_groups": {
+                  "admin": [],
+                  "commit": [],
+                  "ticket": []
+                },
+                "milestones": {},
+                "user": {
+                  "fullname": "Patrick \"\u30de\u30eb\u30bf\u30a4\u30f3\u30a2\u30f3\u30c9\u30ec\u30a2\u30b9\" Uiterwijk",
+                  "name": "puiterwijk"
+                },
+                "date_created": "1501275113",
+                "fullname": "rpms/ipsilon",
+                "settings": {
+                  "issues_default_to_private": False,
+                  "Minimum_score_to_merge_pull-request": -1,
+                  "pull_request_access_only": False,
+                  "Web-hooks": None,
+                  "fedmsg_notifications": True,
+                  "always_merge": False,
+                  "project_documentation": False,
+                  "Enforce_signed-off_commits_in_pull-request": False,
+                  "pull_requests": True,
+                  "Only_assignee_can_merge_pull-request": False,
+                  "issue_tracker": True
+                },
+                "close_status": [],
+                "tags": [],
+                "name": "ipsilon"
+              },
+              "date_modified": "1502052151",
+              "access_users": {
+                "admin": [],
+                "commit": [],
+                "ticket": [],
+                "owner": [
+                  "puiterwijk"
+                ]
+              },
+              "namespace": "rpms",
+              "priorities": {},
+              "id": 22745,
+              "access_groups": {
+                "admin": [],
+                "commit": [],
+                "ticket": []
+              },
+              "milestones": {},
+              "user": {
+                "fullname": "Patrick \"\u30de\u30eb\u30bf\u30a4\u30f3\u30a2\u30f3\u30c9\u30ec\u30a2\u30b9\" Uiterwijk",
+                "name": "puiterwijk"
+              },
+              "date_created": "1502052151",
+              "fullname": "forks/puiterwijk/rpms/ipsilon",
+              "settings": {
+                "issues_default_to_private": False,
+                "Minimum_score_to_merge_pull-request": -1,
+                "pull_request_access_only": False,
+                "Web-hooks": None,
+                "fedmsg_notifications": True,
+                "always_merge": False,
+                "project_documentation": False,
+                "Enforce_signed-off_commits_in_pull-request": False,
+                "pull_requests": False,
+                "Only_assignee_can_merge_pull-request": False,
+                "issue_tracker": False
+              },
+              "close_status": [],
+              "tags": [],
+              "name": "ipsilon"
+            },
+            "agent": "puiterwijk"
+          }
+        }
+
+
 add_doc(locals())
 
 if __name__ == '__main__':

--- a/fedmsg_meta_fedora_infrastructure/tests/pagure.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/pagure.py
@@ -1333,8 +1333,8 @@ class TestProjectTagEdited(Base):
 
 
 class TestProjectForked(Base):
-    """ These messages are published when a someone edited a tag of a
-    project on `pagure <https://pagure.io>`_.
+    """ These messages are published when a someone forks a project on
+    `pagure <https://pagure.io>`_.
     """
     expected_title = "pagure.project.forked"
     expected_subti = 'pingou forked fedmsg to fork/pingou/fedmsg'

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ entry_points = {
         "mm2=fedmsg_meta_fedora_infrastructure.mm2:MirrorManagerProcessor",
         "irc=fedmsg_meta_fedora_infrastructure.karma:KarmaProcessor",
         "pagure=fedmsg_meta_fedora_infrastructure.pagure:PagureProcessor",
+        "pagure_distgit=fedmsg_meta_fedora_infrastructure.pagure:DistGitPagureProcessor",
         "zanata=fedmsg_meta_fedora_infrastructure.zanata:ZanataProcessor",
         "faf=fedmsg_meta_fedora_infrastructure.faf:FAFProcessor",
         "autocloud=fedmsg_meta_fedora_infrastructure.autocloud:"


### PR DESCRIPTION
This commit also adds support for stg vs prod messages (so the links for
example are consistent) and adds a couple of tests as the messages should
be the same since the software is the same, it is assumed two tests are
enough to test the inheritance of the processor and stg vs prod.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>