### PR TITLE
Target py3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 python:
- - "2.6"
  - "2.7"
-# Someday, soon.
-# - "3.2"
+ - "3.6"
 install:
  - pip install --upgrade setuptools pip
  - python setup.py install

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py{27,34}-six{17,19}
+envlist = py{27,36}-six{17,19}
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
 basepython =
     py27: python2.7
-    py34: python3.4
+    py36: python3.6
 deps =
     six17: python-dateutil
     six17: six==1.7.3


### PR DESCRIPTION
We don't have any py2.6 targets anymore, and py3.4 has already flown by.