### PR TITLE
compose: handle Modular messages with no compose_id correctly

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/compose.py
+++ b/fedmsg_meta_fedora_infrastructure/compose.py
@@ -114,7 +114,7 @@ class ComposeProcessor(BaseProcessor):
         branch = msg['msg'].get('branch', 'not-a-number')
         if 'Modular' in branch:
             base = "https://kojipkgs.fedoraproject.org/compose/"
-            return base + msg['msg']['compose_id']
+            return base + msg['msg'].get('compose_id', '')
 
         arch = msg['msg'].get('arch', '')
         if arch:


### PR DESCRIPTION
The code for generating links for compose fedmsgs assumed that
messages for Modular composes would always have a `compose_id`,
but in fact they do not: messages sent before pungi-koji runs,
e.g. the `compose.start` message, don't have a `compose_id`
because it is not known at that time. This caused datagrepper
to fail whenever asked to display any such messages.

It's actually a bit of an interesting question what the 'best'
URL to give for such fedmsgs is, but I'm getting a headache
from thinking about it too hard, so for now let's just do this,
we'll return https://kojipkgs.fedoraproject.org/compose/ as
the 'link' for modular compose fedmsg's with no compose_id.

Signed-off-by: Adam Williamson <awilliam@redhat.com>