### PR TITLE
Substantial rewrite + extension of compose.* tests

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/compose.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/compose.py
@@ -23,17 +23,20 @@ from fedmsg.tests.test_meta import Base
 
 from .common import add_doc
 
+## LEGACY 'BRANCHED' MESSAGES
 
-class TestLegacyComposeBranchedComplete(Base):
-    """ This tests "old school" compose messages.
+
+class TestLegacyPreArchComposeBranchedComplete(Base):
+    """ This tests Branched compose complete messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
     """
     expected_title = "compose.branched.complete"
-    expected_subti = "f18 compose completed"
+    expected_subti = "18 compose completed"
     expected_link = \
-        "https://dl.fedoraproject.org/pub/fedora/linux/development/f18"
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/18"
     expected_objects = set(['branched/primary'])
     msg = {
         "i": 1,
@@ -41,19 +44,20 @@ class TestLegacyComposeBranchedComplete(Base):
         "topic": "org.fedoraproject.prod.compose.branched.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "18",
         },
     }
 
 
-class TestLegacyComposeBranchedStart(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeBranchedStart(Base):
+    """ This tests Branched compose start messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
     """
     expected_title = "compose.branched.start"
-    expected_subti = "f18 compose started"
+    expected_subti = "18 compose started"
     expected_objects = set(['branched/primary'])
     msg = {
         "i": 1,
@@ -61,19 +65,20 @@ class TestLegacyComposeBranchedStart(Base):
         "topic": "org.fedoraproject.prod.compose.branched.start",
         "msg": {
             "log": "start",
-            "branch": "f18",
+            "branch": "18",
         },
     }
 
 
-class TestLegacyComposeBranchedMashStart(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeBranchedMashStart(Base):
+    """ This tests Branched mash start messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
     """
     expected_title = "compose.branched.mash.start"
-    expected_subti = "f18 compose started mashing"
+    expected_subti = "18 compose started mashing"
     expected_objects = set(['branched/primary'])
     msg = {
         "i": 1,
@@ -81,19 +86,20 @@ class TestLegacyComposeBranchedMashStart(Base):
         "topic": "org.fedoraproject.prod.compose.branched.mash.start",
         "msg": {
             "log": "start",
-            "branch": "f18",
+            "branch": "18",
         },
     }
 
 
-class TestLegacyComposeBranchedMashComplete(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeBranchedMashComplete(Base):
+    """ This tests Branched mash complete messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
     """
     expected_title = "compose.branched.mash.complete"
-    expected_subti = "f18 compose finished mashing"
+    expected_subti = "18 compose finished mashing"
     expected_objects = set(['branched/primary'])
     msg = {
         "i": 1,
@@ -101,19 +107,20 @@ class TestLegacyComposeBranchedMashComplete(Base):
         "topic": "org.fedoraproject.prod.compose.branched.mash.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "18",
         },
     }
 
 
-class TestLegacyComposeBranchedPungifyStart(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeBranchedPungifyStart(Base):
+    """ This tests Branched pungify start messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
     """
     expected_title = "compose.branched.pungify.start"
-    expected_subti = "started building boot.iso for f18"
+    expected_subti = "started building boot.iso for 18"
     expected_objects = set(['branched/primary'])
     msg = {
         "i": 1,
@@ -121,19 +128,20 @@ class TestLegacyComposeBranchedPungifyStart(Base):
         "topic": "org.fedoraproject.prod.compose.branched.pungify.start",
         "msg": {
             "log": "start",
-            "branch": "f18",
+            "branch": "18",
         },
     }
 
 
-class TestLegacyComposeBranchedPungifyComplete(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeBranchedPungifyComplete(Base):
+    """ This tests Branched pungify complete messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
     """
     expected_title = "compose.branched.pungify.complete"
-    expected_subti = "finished building boot.iso for f18"
+    expected_subti = "finished building boot.iso for 18"
     expected_objects = set(['branched/primary'])
     msg = {
         "i": 1,
@@ -141,19 +149,20 @@ class TestLegacyComposeBranchedPungifyComplete(Base):
         "topic": "org.fedoraproject.prod.compose.branched.pungify.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "18",
         },
     }
 
 
-class TestLegacyComposeBranchedRsyncStart(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeBranchedRsyncStart(Base):
+    """ This tests Branched rsync start messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
     """
     expected_title = "compose.branched.rsync.start"
-    expected_subti = "started rsyncing f18 compose"
+    expected_subti = "started rsyncing 18 compose"
     expected_objects = set(['branched/primary'])
     msg = {
         "i": 1,
@@ -161,22 +170,23 @@ class TestLegacyComposeBranchedRsyncStart(Base):
         "topic": "org.fedoraproject.prod.compose.branched.rsync.start",
         "msg": {
             "log": "start",
-            "branch": "f18",
+            "branch": "18",
         },
     }
 
 
-class TestLegacyComposeBranchedRsyncComplete(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeBranchedRsyncComplete(Base):
+    """ This tests Branched rsync complete messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
     """
     expected_title = "compose.branched.rsync.complete"
     expected_subti = \
-        "finished rsync of f18 compose"
+        "finished rsync of 18 compose"
     expected_link = \
-        "https://dl.fedoraproject.org/pub/fedora/linux/development/f18"
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/18"
     expected_objects = set(['branched/primary'])
     msg = {
         "i": 1,
@@ -184,13 +194,16 @@ class TestLegacyComposeBranchedRsyncComplete(Base):
         "topic": "org.fedoraproject.prod.compose.branched.rsync.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "18",
         },
     }
 
+## LEGACY RAWHIDE MESSAGES
 
-class TestLegacyComposeRawhideComplete(Base):
-    """ This tests "old school" compose messages.
+
+class TestLegacyPreArchComposeRawhideComplete(Base):
+    """ This tests Rawhide compose complete messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
@@ -211,8 +224,9 @@ class TestLegacyComposeRawhideComplete(Base):
     }
 
 
-class TestLegacyComposeRawhideStart(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeRawhideStart(Base):
+    """ This tests Rawhide compose start messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
@@ -231,8 +245,9 @@ class TestLegacyComposeRawhideStart(Base):
     }
 
 
-class TestLegacyComposeRawhideMashStart(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeRawhideMashStart(Base):
+    """ This tests Rawhide mash start messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
@@ -251,8 +266,9 @@ class TestLegacyComposeRawhideMashStart(Base):
     }
 
 
-class TestLegacyComposeRawhideMashComplete(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeRawhideMashComplete(Base):
+    """ This tests Rawhide mash complete messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
@@ -271,8 +287,9 @@ class TestLegacyComposeRawhideMashComplete(Base):
     }
 
 
-class TestLegacyComposeRawhideRsyncStart(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeRawhideRsyncStart(Base):
+    """ This tests Rawhide rsync start messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
@@ -291,8 +308,9 @@ class TestLegacyComposeRawhideRsyncStart(Base):
     }
 
 
-class TestLegacyComposeRawhideRsyncComplete(Base):
-    """ This tests "old school" compose messages.
+class TestLegacyPreArchComposeRawhideRsyncComplete(Base):
+    """ This tests Rawhide rsync complete messages from before the
+    'arch' key was added to the fedmsg.
 
     :mod:`fedmsg.meta` needs to be able to handle them because they are
     stored, forever, in datanommer.
@@ -312,260 +330,80 @@ class TestLegacyComposeRawhideRsyncComplete(Base):
         },
     }
 
+class TestLegacyPreShortComposeRawhideStart(Base):
+    """ This tests Rawhide compose start messages from before the
+    'short' key was added to the fedmsg.
 
-class TestComposeBranchedComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished composing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
     """
-    expected_title = "compose.branched.complete"
-    expected_subti = "f18 compose completed"
+    expected_title = "compose.rawhide.start"
+    expected_subti = "rawhide compose started"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.rawhide.start",
+        "msg": {
+            "log": "start",
+            "branch": "rawhide",
+            "arch": "",
+        },
+    }
+
+
+class TestLegacyPreCidComposeRawhideRsyncStart(Base):
+    """ This tests Rawhide rsync start messages from before the
+    'short'  and 'compose_id' keys were added to the fedmsg.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
+    """
+    expected_title = "compose.rawhide.rsync.start"
+    expected_subti = "started rsyncing rawhide compose"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.rawhide.rsync.start",
+        "msg": {
+            "log": "start",
+            "branch": "rawhide",
+            "arch": "",
+        },
+    }
+
+
+class TestLegacyPreCidComposeRawhideRsyncComplete(Base):
+    """ This tests Rawhide rsync complete messages from before the
+    'short'  and 'compose_id' keys were added to the fedmsg.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
+    """
+    expected_title = "compose.rawhide.rsync.complete"
+    expected_subti = "finished rsync of rawhide compose"
     expected_link = \
-        "https://dl.fedoraproject.org/pub/fedora/linux/development/f18"
-    expected_objects = set(['branched/primary'])
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide"
+    expected_objects = set(['rawhide/primary'])
     msg = {
         "i": 1,
         "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.branched.complete",
+        "topic": "org.fedoraproject.prod.compose.rawhide.rsync.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "rawhide",
             "arch": "",
         },
     }
 
 
-class TestModularComposeBranchedComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished composing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message for the Modular compose.
-    """
-    expected_title = "compose.27.complete"
-    expected_subti = "Modular-27 compose completed"
-    expected_link = \
-        "https://kojipkgs.fedoraproject.org/compose/Fedora-Modular-27-20170821.n.0"
-    expected_objects = set(['27/primary'])
-    msg = {
-        "i": 1,
-        "msg": {
-            "arch": "",
-            "branch": "Modular-27",
-            "compose_id": "Fedora-Modular-27-20170821.n.0",
-            "log": "done"
-        },
-        "msg_id": "2017-12da6801-49af-40ab-82bc-138a54c346ff",
-        "timestamp": 1503339691.0,
-        "topic": "org.fedoraproject.prod.compose.27.complete",
-        "username": "root"
-    }
+class TestLegacyPreCidComposeRawhideComplete(Base):
+    """ This tests Rawhide compose complete messages from before the
+    'short'  and 'compose_id' keys were added to the fedmsg.
 
-
-
-class TestComposeEPELBetaComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have **finished composing** the EPEL beta.
-    """
-    expected_title = "compose.epelbeta.complete"
-    expected_subti = "epelbeta compose completed"
-    expected_link = "https://dl.fedoraproject.org/pub/epel/beta/7/"
-    expected_objects = set(['epelbeta/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.epelbeta.complete",
-        "msg": {
-            "log": "done",
-        },
-    }
-
-
-class TestComposeBranchedStart(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **begun composing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.branched.start"
-    expected_subti = "f18 compose started"
-    expected_objects = set(['branched/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.branched.start",
-        "msg": {
-            "log": "start",
-            "branch": "f18",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeBranchedMashStart(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **begun mashing** for
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.branched.mash.start"
-    expected_subti = "f18 compose started mashing"
-    expected_objects = set(['branched/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.branched.mash.start",
-        "msg": {
-            "log": "start",
-            "branch": "f18",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeBranchedMashComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished mashing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.branched.mash.complete"
-    expected_subti = "f18 compose finished mashing"
-    expected_objects = set(['branched/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.branched.mash.complete",
-        "msg": {
-            "log": "done",
-            "branch": "f18",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeBranchedPungifyStart(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    started the `pungify <https://fedorahosted.org/pungi/>`_ process for
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.branched.pungify.start"
-    expected_subti = "started building boot.iso for f18"
-    expected_objects = set(['branched/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.branched.pungify.start",
-        "msg": {
-            "log": "start",
-            "branch": "f18",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeBranchedPungifyComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    completed the `pungify <https://fedorahosted.org/pungi/>`_ process for
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.branched.pungify.complete"
-    expected_subti = "finished building boot.iso for f18"
-    expected_objects = set(['branched/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.branched.pungify.complete",
-        "msg": {
-            "log": "done",
-            "branch": "f18",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeBranchedRsyncStart(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    begun **rsyncing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.branched.rsync.start"
-    expected_subti = "started rsyncing f18 compose"
-    expected_objects = set(['branched/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.branched.rsync.start",
-        "msg": {
-            "log": "start",
-            "branch": "f18",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeBranchedRsyncComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    finished **rsyncing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.branched.rsync.complete"
-    expected_subti = \
-        "finished rsync of f18 compose"
-    expected_link = \
-        "https://dl.fedoraproject.org/pub/fedora/linux/development/f18"
-    expected_objects = set(['branched/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.branched.rsync.complete",
-        "msg": {
-            "log": "done",
-            "branch": "f18",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeRawhideComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
     """
     expected_title = "compose.rawhide.complete"
     expected_subti = "rawhide compose completed"
@@ -584,13 +422,85 @@ class TestComposeRawhideComplete(Base):
     }
 
 
-class TestModularComposeRawhideComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message for the **Modular** compose.
+class TestLegacyPreShortComposeRawhideRsyncStart(Base):
+    """ This tests Rawhide rsync start messages from before the
+    'short'key was added to the fedmsg, but after 'compose_id' was.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
+    """
+    expected_title = "compose.rawhide.rsync.start"
+    expected_subti = "started rsyncing rawhide compose"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512395453.0,
+        "topic": "org.fedoraproject.prod.compose.rawhide.rsync.start",
+        "msg": {
+            "log": "start",
+            "branch": "rawhide",
+            "arch": "",
+            "compose_id": "Fedora-Rawhide-20171204.n.0",
+        },
+    }
+
+
+class TestLegacyPreShortComposeRawhideRsyncComplete(Base):
+    """ This tests Rawhide rsync complete messages from before the
+    'short'key was added to the fedmsg, but after 'compose_id' was.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
+    """
+    expected_title = "compose.rawhide.rsync.complete"
+    expected_subti = "finished rsync of rawhide compose"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512313750.0,
+        "topic": "org.fedoraproject.prod.compose.rawhide.rsync.complete",
+        "msg": {
+            "log": "done",
+            "branch": "rawhide",
+            "arch": "",
+            "compose_id": "Fedora-Rawhide-20171203.n.0",
+        },
+    }
+
+
+class TestLegacyPreShortComposeRawhideComplete(Base):
+    """ This tests Rawhide compose complete messages from before the
+    'short'key was added to the fedmsg, but after 'compose_id' was.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
+    """
+    expected_title = "compose.rawhide.complete"
+    expected_subti = "rawhide compose completed"
+    expected_objects = set(['rawhide/primary'])
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide"
+    msg = {
+        "i": 1,
+        "timestamp": 1512398352.0,
+        "topic": "org.fedoraproject.prod.compose.rawhide.complete",
+        "msg": {
+            "log": "done",
+            "branch": "rawhide",
+            "arch": "",
+            "compose_id": "Fedora-Rawhide-20171204.n.0",
+        },
+    }
+
+
+class TestLegacyModularComposeRawhideComplete(Base):
+    """ This tests compose complete messages for Rawhide modular composes.
+    These were replaced by the 'bikeshed' composes in 2017-11.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
     """
     expected_title = "compose.rawhide.complete"
     expected_subti = "Modular-Rawhide compose completed"
@@ -610,138 +520,24 @@ class TestModularComposeRawhideComplete(Base):
         "topic": "org.fedoraproject.prod.compose.rawhide.complete",
     }
 
-
-class TestComposeRawhideStart(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **started** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.rawhide.start"
-    expected_subti = "rawhide compose started"
-    expected_objects = set(['rawhide/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.rawhide.start",
-        "msg": {
-            "log": "start",
-            "branch": "rawhide",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeRawhideMashStart(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **started mashing** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.rawhide.mash.start"
-    expected_subti = "rawhide compose started mashing"
-    expected_objects = set(['rawhide/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.rawhide.mash.start",
-        "msg": {
-            "log": "start",
-            "branch": "rawhide",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeRawhideMashComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished mashing** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.rawhide.mash.complete"
-    expected_subti = "rawhide compose finished mashing"
-    expected_objects = set(['rawhide/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.rawhide.mash.complete",
-        "msg": {
-            "log": "done",
-            "branch": "rawhide",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeRawhideRsyncStart(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **started rsyncing** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.rawhide.rsync.start"
-    expected_subti = "started rsyncing rawhide compose"
-    expected_objects = set(['rawhide/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.rawhide.rsync.start",
-        "msg": {
-            "log": "start",
-            "branch": "rawhide",
-            "arch": "",
-        },
-    }
-
-
-class TestComposeRawhideRsyncComplete(Base):
-    """ The `release engineering
-    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished rsyncing** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **primary** arch message (the empty string signifies primary).
-    """
-    expected_title = "compose.rawhide.rsync.complete"
-    expected_subti = "finished rsync of rawhide compose"
-    expected_link = \
-        "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide"
-    expected_objects = set(['rawhide/primary'])
-    msg = {
-        "i": 1,
-        "timestamp": 1344447839.891876,
-        "topic": "org.fedoraproject.prod.compose.rawhide.rsync.complete",
-        "msg": {
-            "log": "done",
-            "branch": "rawhide",
-            "arch": "",
-        },
-    }
+## SECONDARY ARCH 'BRANCHED' MESSAGES
 
 
 class TestSecondaryArchComposeBranchedComplete(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
+    used to produce these messages when they had
     **finished composing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    a secondary arch compose for a Branched release. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
+    # no need to include both this and the primary arch test in the docs
+    nodoc = True
     expected_title = "compose.branched.complete"
-    expected_subti = "f18 compose (arm) completed"
+    expected_subti = "18 compose (arm) completed"
     expected_link = \
         "https://dl.fedoraproject.org/pub/fedora-secondary/" + \
-        "development/f18"
+        "development/18"
     expected_objects = set(['branched/arm'])
     msg = {
         "i": 1,
@@ -749,7 +545,7 @@ class TestSecondaryArchComposeBranchedComplete(Base):
         "topic": "org.fedoraproject.prod.compose.branched.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "18",
             "arch": "arm",
         },
     }
@@ -758,14 +554,15 @@ class TestSecondaryArchComposeBranchedComplete(Base):
 class TestSecondaryArchComposeBranchedStart(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
+    used to produce these messages when they had
     **started composing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    a secondary arch compose for a Branched release. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
+    # no need to include both this and the primary arch test in the docs
+    nodoc = True
     expected_title = "compose.branched.start"
-    expected_subti = "f18 compose (arm) started"
+    expected_subti = "18 compose (arm) started"
     expected_objects = set(['branched/arm'])
     msg = {
         "i": 1,
@@ -773,7 +570,7 @@ class TestSecondaryArchComposeBranchedStart(Base):
         "topic": "org.fedoraproject.prod.compose.branched.start",
         "msg": {
             "log": "start",
-            "branch": "f18",
+            "branch": "18",
             "arch": "arm",
         },
     }
@@ -782,14 +579,15 @@ class TestSecondaryArchComposeBranchedStart(Base):
 class TestSecondaryArchComposeBranchedMashStart(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
+    used to produce these messages when they had
     **started mashing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    a secondary arch compose for a Branched release. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
+    # no need to include both this and the primary arch test in the docs
+    nodoc = True
     expected_title = "compose.branched.mash.start"
-    expected_subti = "f18 compose (arm) started mashing"
+    expected_subti = "18 compose (arm) started mashing"
     expected_objects = set(['branched/arm'])
     msg = {
         "i": 1,
@@ -797,7 +595,7 @@ class TestSecondaryArchComposeBranchedMashStart(Base):
         "topic": "org.fedoraproject.prod.compose.branched.mash.start",
         "msg": {
             "log": "start",
-            "branch": "f18",
+            "branch": "18",
             "arch": "arm",
         },
     }
@@ -806,14 +604,15 @@ class TestSecondaryArchComposeBranchedMashStart(Base):
 class TestSecondaryArchComposeBranchedMashComplete(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
+    used to produce these messages when they had
     **finished mashing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    a secondary arch compose for a Branched release. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
+    # no need to include both this and the primary arch test in the docs
+    nodoc = True
     expected_title = "compose.branched.mash.complete"
-    expected_subti = "f18 compose (arm) finished mashing"
+    expected_subti = "18 compose (arm) finished mashing"
     expected_objects = set(['branched/arm'])
     msg = {
         "i": 1,
@@ -821,7 +620,7 @@ class TestSecondaryArchComposeBranchedMashComplete(Base):
         "topic": "org.fedoraproject.prod.compose.branched.mash.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "18",
             "arch": "arm",
         },
     }
@@ -830,14 +629,15 @@ class TestSecondaryArchComposeBranchedMashComplete(Base):
 class TestSecondaryArchComposeBranchedPungifyStart(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
+    used to produce these messages when they had
     started the `pungify <https://fedorahosted.org/pungi/>`_ process for
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    a secondary arch compose for a Branched release. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
+    # no need to include both this and the primary arch test in the docs
+    nodoc = True
     expected_title = "compose.branched.pungify.start"
-    expected_subti = "started building boot.iso for f18 (arm)"
+    expected_subti = "started building boot.iso for 18 (arm)"
     expected_objects = set(['branched/arm'])
     msg = {
         "i": 1,
@@ -845,7 +645,7 @@ class TestSecondaryArchComposeBranchedPungifyStart(Base):
         "topic": "org.fedoraproject.prod.compose.branched.pungify.start",
         "msg": {
             "log": "start",
-            "branch": "f18",
+            "branch": "18",
             "arch": "arm",
         },
     }
@@ -854,14 +654,15 @@ class TestSecondaryArchComposeBranchedPungifyStart(Base):
 class TestSecondaryArchComposeBranchedPungifyComplete(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
+    used to produce these messages when they had
     completed the `pungify <https://fedorahosted.org/pungi/>`_ process for
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    a secondary arch compose for a Branched release. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
+    # no need to include both this and the primary arch test in the docs
+    nodoc = True
     expected_title = "compose.branched.pungify.complete"
-    expected_subti = "finished building boot.iso for f18 (arm)"
+    expected_subti = "finished building boot.iso for 18 (arm)"
     expected_objects = set(['branched/arm'])
     msg = {
         "i": 1,
@@ -869,7 +670,7 @@ class TestSecondaryArchComposeBranchedPungifyComplete(Base):
         "topic": "org.fedoraproject.prod.compose.branched.pungify.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "18",
             "arch": "arm",
         },
     }
@@ -878,14 +679,15 @@ class TestSecondaryArchComposeBranchedPungifyComplete(Base):
 class TestSecondaryArchComposeBranchedRsyncStart(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
+    used to produce these messages when they had
     **started rsyncing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    a secondary arch compose for a Branched release. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
+    # no need to include both this and the primary arch test in the docs
+    nodoc = True
     expected_title = "compose.branched.rsync.start"
-    expected_subti = "started rsyncing f18 compose (arm)"
+    expected_subti = "started rsyncing 18 compose (arm)"
     expected_objects = set(['branched/arm'])
     msg = {
         "i": 1,
@@ -893,7 +695,7 @@ class TestSecondaryArchComposeBranchedRsyncStart(Base):
         "topic": "org.fedoraproject.prod.compose.branched.rsync.start",
         "msg": {
             "log": "start",
-            "branch": "f18",
+            "branch": "18",
             "arch": "arm",
         },
     }
@@ -902,18 +704,19 @@ class TestSecondaryArchComposeBranchedRsyncStart(Base):
 class TestSecondaryArchComposeBranchedRsyncComplete(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
+    used to produce these messages when they had
     **finished rsyncing**
-    whatever the current branched distribution version is.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    a secondary arch compose for a Branched release. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
+    # no need to include both this and the primary arch test in the docs
+    nodoc = True
     expected_title = "compose.branched.rsync.complete"
     expected_subti = \
-        "finished rsync of f18 compose (arm)"
+        "finished rsync of 18 compose (arm)"
     expected_link = \
         "https://dl.fedoraproject.org/pub/fedora-secondary/" + \
-        "development/f18"
+        "development/18"
     expected_objects = set(['branched/arm'])
     msg = {
         "i": 1,
@@ -921,19 +724,21 @@ class TestSecondaryArchComposeBranchedRsyncComplete(Base):
         "topic": "org.fedoraproject.prod.compose.branched.rsync.complete",
         "msg": {
             "log": "done",
-            "branch": "f18",
+            "branch": "18",
             "arch": "arm",
         },
     }
 
+## SECONDARY ARCH RAWHIDE MESSAGES
 
-class TestSecondaryArchComposeRawhideComplete(Base):
+
+class TestLegacySecondaryArchComposeRawhideComplete(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    used to produce these messages when they had
+    **finished**
+    a Rawhide secondary arch compose. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
     expected_title = "compose.rawhide.complete"
     expected_subti = "rawhide compose (arm) completed"
@@ -953,13 +758,13 @@ class TestSecondaryArchComposeRawhideComplete(Base):
     }
 
 
-class TestSecondaryArchComposeRawhideStart(Base):
+class TestLegacySecondaryArchComposeRawhideStart(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **started** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    used to produce these messages when they had
+    **started**
+    a Rawhide secondary arch compose. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
     expected_title = "compose.rawhide.start"
     expected_subti = "rawhide compose (arm) started"
@@ -976,13 +781,13 @@ class TestSecondaryArchComposeRawhideStart(Base):
     }
 
 
-class TestSecondaryArchComposeRawhideMashStart(Base):
+class TestLegacySecondaryArchComposeRawhideMashStart(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **started mashing** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    used to produce these messages when they had
+    **started mashing**
+    a Rawhide secondary arch compose. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
     expected_title = "compose.rawhide.mash.start"
     expected_subti = "rawhide compose (arm) started mashing"
@@ -999,13 +804,13 @@ class TestSecondaryArchComposeRawhideMashStart(Base):
     }
 
 
-class TestSecondaryArchComposeRawhideMashComplete(Base):
+class TestLegacySecondaryArchComposeRawhideMashComplete(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished mashing** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    used to produce these messages when they had
+    **finished mashing**
+    a Rawhide secondary arch compose. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
     expected_title = "compose.rawhide.mash.complete"
     expected_subti = "rawhide compose (arm) finished mashing"
@@ -1022,13 +827,13 @@ class TestSecondaryArchComposeRawhideMashComplete(Base):
     }
 
 
-class TestSecondaryArchComposeRawhideRsyncStart(Base):
+class TestLegacySecondaryArchComposeRawhideRsyncStart(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **started rsyncing** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    used to produce these messages when they had
+    **started rsyncing**
+    a Rawhide secondary arch compose. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
     expected_title = "compose.rawhide.rsync.start"
     expected_subti = "started rsyncing rawhide compose (arm)"
@@ -1045,13 +850,13 @@ class TestSecondaryArchComposeRawhideRsyncStart(Base):
     }
 
 
-class TestSecondaryArchComposeRawhideRsyncComplete(Base):
+class TestLegacySecondaryArchComposeRawhideRsyncComplete(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have
-    **finished rsyncing** the rawhide compose.  They are published
-    for both primary and secondary architectures.  The example here is of a
-    **secondary** arch message.
+    used to produce these messages when they had
+    **finished rsyncing**
+    a Rawhide secondary arch compose. Since the Pungi 4
+    migration, all arches are included in the same compose process.
     """
     expected_title = "compose.rawhide.rsync.complete"
     expected_subti = \
@@ -1071,13 +876,723 @@ class TestSecondaryArchComposeRawhideRsyncComplete(Base):
         },
     }
 
+## OLD (BUT NOT LEGACY) 'BRANCHED' MESSAGES
 
-class TestMakeUpdatesStarted(Base):
+
+class TestComposeBranchedComplete(Base):
     """ The `release engineering
     <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
-    produce these messages when they have **started** the make-updates process
-    (which is how we do periodic re-spins of our cloud, atomic, and docker
-    images).  Here's an example of a message from F23:
+    used to produce these messages when they
+    **finished composing**
+    whatever the current branched distribution version was. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, instead the topic for messages
+    related to Branched composes will include the release number (e.g.
+    'compose.27.complete').
+    """
+    expected_title = "compose.branched.complete"
+    expected_subti = "18 compose completed"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/18"
+    expected_objects = set(['branched/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.branched.complete",
+        "msg": {
+            "log": "done",
+            "branch": "18",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeBranchedStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **began composing**
+    whatever the current branched distribution version was. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, instead the topic for messages
+    related to Branched composes will include the release number (e.g.
+    'compose.27.start').
+    """
+    expected_title = "compose.branched.start"
+    expected_subti = "18 compose started"
+    expected_link = "https://dl.fedoraproject.org/pub/fedora/linux/development/18"
+    expected_objects = set(['branched/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.branched.start",
+        "msg": {
+            "log": "start",
+            "branch": "18",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeBranchedMashStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **began mashing**
+    whatever the current branched distribution version was. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, and there are no mash-related
+    messages published by the current compose process.
+    """
+    expected_title = "compose.branched.mash.start"
+    expected_subti = "18 compose started mashing"
+    expected_objects = set(['branched/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.branched.mash.start",
+        "msg": {
+            "log": "start",
+            "branch": "18",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeBranchedMashComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **finished mashing**
+    whatever the current branched distribution version was. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, and there are no mash-related
+    messages published by the current compose process.
+    """
+    expected_title = "compose.branched.mash.complete"
+    expected_subti = "18 compose finished mashing"
+    expected_objects = set(['branched/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.branched.mash.complete",
+        "msg": {
+            "log": "done",
+            "branch": "18",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeBranchedPungifyStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **started to pungify**
+    whatever the current branched distribution version was. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, and there are no pungify
+    messages published by the current compose process.
+    """
+    expected_title = "compose.branched.pungify.start"
+    expected_subti = "started building boot.iso for 18"
+    expected_objects = set(['branched/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.branched.pungify.start",
+        "msg": {
+            "log": "start",
+            "branch": "18",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeBranchedPungifyComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **finished pungifying**
+    whatever the current branched distribution version was. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, and there are no pungify
+    messages published by the current compose process.
+    """
+    expected_title = "compose.branched.pungify.complete"
+    expected_subti = "finished building boot.iso for 18"
+    expected_objects = set(['branched/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.branched.pungify.complete",
+        "msg": {
+            "log": "done",
+            "branch": "18",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeBranchedRsyncStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **began syncing out (publishing, effectively)**
+    whatever the current branched distribution version was. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, instead the topic for messages
+    related to Branched composes will include the release number (e.g.
+    'compose.27.rsync.start').
+    """
+    expected_title = "compose.branched.rsync.start"
+    expected_subti = "started rsyncing 18 compose"
+    expected_objects = set(['branched/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.branched.rsync.start",
+        "msg": {
+            "log": "start",
+            "branch": "18",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeBranchedRsyncComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **finished syncing out (publishing, effectively)**
+    whatever the current branched distribution version was. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, instead the topic for messages
+    related to Branched composes will include the release number (e.g.
+    'compose.27.rsync.complete').
+    """
+    expected_title = "compose.branched.rsync.complete"
+    expected_subti = \
+        "finished rsync of 18 compose"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/18"
+    expected_objects = set(['branched/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.branched.rsync.complete",
+        "msg": {
+            "log": "done",
+            "branch": "18",
+            "arch": "",
+        },
+    }
+
+## OLD (BUT NOT LEGACY) RAWHIDE MESSAGES
+
+
+class TestComposeRawhideMashStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **started mashing**
+    the rawhide compose. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, and there are no mash-related
+    messages published by the current compose process.
+    """
+    expected_title = "compose.rawhide.mash.start"
+    expected_subti = "rawhide compose started mashing"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.rawhide.mash.start",
+        "msg": {
+            "log": "start",
+            "branch": "rawhide",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeRawhideMashComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **finished mashing**
+    the rawhide compose. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, and there are no mash-related
+    messages published by the current compose process.
+    """
+    expected_title = "compose.rawhide.mash.complete"
+    expected_subti = "rawhide compose finished mashing"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.rawhide.mash.complete",
+        "msg": {
+            "log": "done",
+            "branch": "rawhide",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeRawhidePungifyStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **started creating a boot.iso**
+    for the rawhide compose. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, and there are no pungify
+    messages published by the current compose process.
+    """
+    expected_title = "compose.rawhide.pungify.start"
+    expected_subti = "started building boot.iso for rawhide"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.rawhide.pungify.start",
+        "msg": {
+            "log": "start",
+            "branch": "rawhide",
+            "arch": "",
+        },
+    }
+
+
+class TestComposeRawhidePungifyComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they
+    **finished creating a boot.iso**
+    for the rawhide compose. They were published
+    for both primary and secondary architectures.  The example here is of a
+    **primary** arch message (the empty string signifies primary). Messages
+    with this topic are not currently published, and there are no pungify
+    messages published by the current compose process.
+    """
+    expected_title = "compose.rawhide.pungify.complete"
+    expected_subti = "finished building boot.iso for rawhide"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.rawhide.pungify.complete",
+        "msg": {
+            "log": "done",
+            "branch": "rawhide",
+            "arch": "",
+        },
+    }
+
+## CURRENT RAWHIDE MESSAGES
+
+
+class TestComposeRawhideStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **started** the rawhide compose.
+    """
+    expected_title = "compose.rawhide.start"
+    expected_subti = "rawhide compose started"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.rawhide.start",
+        "msg": {
+            "log": "start",
+            "branch": "rawhide",
+            "arch": "",
+            "compose_id": "Fedora-Rawhide-20171215.n.0",
+            "short": "Fedora",
+        },
+    }
+
+
+class TestComposeRawhideRsyncStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **started syncing out**
+    a completed rawhide compose.
+    """
+    expected_title = "compose.rawhide.rsync.start"
+    expected_subti = "started rsyncing rawhide compose"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512395453.0,
+        "topic": "org.fedoraproject.prod.compose.rawhide.rsync.start",
+        "msg": {
+            "log": "start",
+            "branch": "rawhide",
+            "arch": "",
+            "compose_id": "Fedora-Rawhide-20171215.n.0",
+            "short": "Fedora",
+        },
+    }
+
+
+class TestComposeRawhideRsyncComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **finished syncing out**
+    a completed rawhide compose.
+    """
+    expected_title = "compose.rawhide.rsync.complete"
+    expected_subti = "finished rsync of rawhide compose"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide"
+    expected_objects = set(['rawhide/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512313750.0,
+        "topic": "org.fedoraproject.prod.compose.rawhide.rsync.complete",
+        "msg": {
+            "log": "done",
+            "branch": "rawhide",
+            "arch": "",
+            "compose_id": "Fedora-Rawhide-20171215.n.0",
+            "short": "Fedora",
+        },
+    }
+
+
+class TestComposeRawhideComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **finished**
+    a rawhide compose.
+    """
+    expected_title = "compose.rawhide.complete"
+    expected_subti = "rawhide compose completed"
+    expected_objects = set(['rawhide/primary'])
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide"
+    msg = {
+        "i": 1,
+        "timestamp": 1512398352.0,
+        "topic": "org.fedoraproject.prod.compose.rawhide.complete",
+        "msg": {
+            "log": "done",
+            "branch": "rawhide",
+            "arch": "",
+            "compose_id": "Fedora-Rawhide-20171215.n.0",
+            "short": "Fedora",
+        },
+    }
+
+## CURRENT MODULAR BIKESHED COMPOSE MESSAGES
+
+
+class TestComposeBikeshedStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **started** a 'bikeshed' compose
+    (basically like a Rawhide compose, but for modular).
+    """
+    expected_title = "compose.bikeshed.start"
+    expected_subti = "bikeshed compose started"
+    expected_objects = set(['bikeshed/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512756914.0,
+        "msg_id": "2017-7e497c3e-14b6-497f-a016-79cf9b591585",
+        "topic": "org.fedoraproject.prod.compose.bikeshed.start",
+        "msg": {
+            "log": "start",
+            "branch": "bikeshed",
+            "arch": "",
+            "short": "Fedora-Modular",
+        },
+    }
+
+
+class TestComposeBikeshedComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **finished** a 'bikeshed' compose
+    (basically like a Rawhide compose, but for modular).
+    """
+    expected_title = "compose.bikeshed.complete"
+    expected_subti = "bikeshed compose completed"
+    expected_objects = set(['bikeshed/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512756914.0,
+        "topic": "org.fedoraproject.prod.compose.bikeshed.complete",
+        "msg": {
+            "log": "done",
+            "branch": "bikeshed",
+            "arch": "",
+            "compose_id": "Fedora-Modular-Bikeshed-20171208.n.0",
+            "short": "Fedora-Modular",
+        },
+    }
+
+## LEGACY MODULAR BIKESHED COMPOSE MESSAGES
+
+
+class TestLegacyPre201712ComposeBikeshedComplete(Base):
+    """ This tests bikeshed messages from before the fixes in 2017-12,
+    which added the 'short' key, changed the 'branch' value from
+    'Modular-Bikeshed' to 'bikeshed', and ensured the compose_id was
+    present for post-compose-complete messages.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
+    """
+    expected_title = "compose.bikeshed.complete"
+    expected_subti = "Modular-Bikeshed compose completed"
+    expected_objects = set(['bikeshed/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512411407.0,
+        "msg_id": "2017-7973eb0b-0715-40c2-9903-01c31dd25e06",
+        "topic": "org.fedoraproject.prod.compose.bikeshed.complete",
+        "msg": {
+            "log": "done",
+            "branch": "Modular-Bikeshed",
+            "arch": "",
+            "compose_id": "",
+        },
+    }
+
+## CURRENT NUMERIC COMPOSE MESSAGES
+
+
+class TestComposeNumericStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **started** a compose for a
+    numbered release. This could be a Branched compose, or a post-release
+    two-week Atomic, Docker, or Cloud compose: the 'short' and 'compose_id'
+    values can be used to differentiate. The message topic obviously differs
+    based on the release, this one is only an example.
+    """
+    expected_title = "compose.28.start"
+    expected_subti = "28 compose started"
+    expected_objects = set(['28/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.28.start",
+        "msg": {
+            "log": "start",
+            "branch": "28",
+            "arch": "",
+            "compose_id": "Fedora-28-20171215.n.0",
+            "short": "Fedora",
+        },
+    }
+
+
+class TestComposeNumericRsyncStart(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **started syncing out** a compose for
+    a numbered release. This could be a Branched compose, or a post-release
+    two-week Atomic, Docker, or Cloud compose: the 'short' and 'compose_id'
+    values can be used to differentiate. The message topic obviously differs
+    based on the release, this one is only an example.
+    """
+    expected_title = "compose.28.rsync.start"
+    expected_subti = "started rsyncing 28 compose"
+    expected_objects = set(['28/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512395453.0,
+        "topic": "org.fedoraproject.prod.compose.28.rsync.start",
+        "msg": {
+            "log": "start",
+            "branch": "28",
+            "arch": "",
+            "compose_id": "Fedora-Atomic-28-20171215.n.0",
+            "short": "Fedora-Atomic",
+        },
+    }
+
+
+class TestComposeNumericRsyncComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **finished syncing out** a compose
+    for a numbered release. This could be a Branched compose, or a post-release
+    two-week Atomic, Docker, or Cloud compose: the 'short' and 'compose_id'
+    values can be used to differentiate. The message topic obviously differs
+    based on the release, this one is only an example.
+    """
+    expected_title = "compose.28.rsync.complete"
+    expected_subti = "finished rsync of 28 compose"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/28"
+    expected_objects = set(['28/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1512313750.0,
+        "topic": "org.fedoraproject.prod.compose.28.rsync.complete",
+        "msg": {
+            "log": "done",
+            "branch": "28",
+            "arch": "",
+            "compose_id": "Fedora-Cloud-28-20171215.n.0",
+            "short": "Fedora-Cloud",
+        },
+    }
+
+
+class TestComposeNumericComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **finished** a compose for a
+    numbered release. This could be a Branched compose, or a post-release
+    two-week Atomic, Docker, or Cloud compose: the 'short' and 'compose_id'
+    values can be used to differentiate. The message topic obviously differs
+    based on the release, this one is only an example.
+    """
+    expected_title = "compose.28.complete"
+    expected_subti = "28 compose completed"
+    expected_objects = set(['28/primary'])
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/28"
+    msg = {
+        "i": 1,
+        "timestamp": 1512398352.0,
+        "topic": "org.fedoraproject.prod.compose.28.complete",
+        "msg": {
+            "log": "done",
+            "branch": "28",
+            "arch": "",
+            "compose_id": "Fedora-Docker-28-20171215.n.0",
+            "short": "Fedora-Docker",
+        },
+    }
+
+
+class TestComposeNumericModularComplete(Base):
+    """This is just an additional test for current numeric Modular
+    compose messages, as we don't have enough tests for all shortnames
+    above. Note, it may be the case that none of these ever actually
+    exist - F27 modular composes were stopped just before the 2017-12
+    changes that would have produced this form of message, and we may
+    roll modular deliverables into the main compose process before 28
+    branches. But let's test this format just in case.
+    """
+    # no need to doc this, previous class is the doc
+    nodoc = True
+    expected_title = "compose.28.complete"
+    expected_subti = "28 compose completed"
+    expected_objects = set(['28/primary'])
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/28"
+    msg = {
+        "i": 1,
+        "timestamp": 1512398352.0,
+        "topic": "org.fedoraproject.prod.compose.28.complete",
+        "msg": {
+            "log": "done",
+            "branch": "28",
+            "arch": "",
+            "compose_id": "Fedora-Modular-28-20171215.n.0",
+            "short": "Fedora-Modular",
+        },
+    }
+
+## LEGACY NUMERIC COMPOSE MESSAGES
+
+
+class TestLegacyPre201712ComposeNumericComplete(Base):
+    """ This tests numeric messages from before the fixes in 2017-12,
+    which added the 'short' key and ensured the compose_id was present
+    for post-compose-complete messages.
+
+    Note there are no secondary arch messages of this type; we switched
+    to numeric messages with the Pungi 4 migration, which also ended
+    separate secondary arch composes.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
+    """
+    expected_title = "compose.23.complete"
+    expected_subti = "23 compose completed"
+    expected_objects = set(['23/primary'])
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/23"
+    msg = {
+        "i": 1,
+        "timestamp": 1464301992.0,
+        "msg_id": "2016-d6086626-88c3-41e0-8904-449c372fc33d",
+        "topic": "org.fedoraproject.prod.compose.23.complete",
+        "msg": {
+            "log": "done",
+            "branch": "23",
+            "arch": "",
+        },
+    }
+
+
+class TestLegacyPre201712ComposeNumericModularComplete(Base):
+    """ This tests numeric messages for modular composes from before
+    the fixes in 2017-12, which added the 'short' key, and changed the
+    'branch' value from 'Modular-NN' to 'NN'.
+
+    For the historical record, the 'compose_id' value in these fedmsgs
+    is often a lie: these messages would be sent out even when the
+    pungi compose failed, and in those cases, the 'compose_id' would
+    in fact be the ID of the previous successful compose, not the ID
+    of the failed compose that actually triggered the fedmsg.
+
+    :mod:`fedmsg.meta` needs to be able to handle them because they are
+    stored, forever, in datanommer.
+    """
+    expected_title = "compose.27.complete"
+    expected_subti = "Modular-27 compose completed"
+    expected_objects = set(['27/primary'])
+    expected_link = \
+        "https://kojipkgs.fedoraproject.org/compose/Fedora-Modular-27-20171123.n.1"
+    msg = {
+        "i": 1,
+        "timestamp": 1511450794.0,
+        "msg_id": "2017-ab0bc502-29d3-47b7-bd54-c71b50dcbd76",
+        "topic": "org.fedoraproject.prod.compose.27.complete",
+        "msg": {
+            "log": "done",
+            "branch": "Modular-27",
+            "arch": "",
+            "compose_id": "Fedora-Modular-27-20171123.n.1",
+        },
+    }
+
+## OLD MAKE-UPDATES PROCESS MESSAGES
+
+
+class TestComposeMakeUpdatesStarted(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they had **started** the make-updates
+    process (which was how we did periodic re-spins of our cloud, atomic, and
+    docker images during the Fedora 21, 22 and 23 cycles). From Fedora 24
+    onwards, these re-spins are produced with Pungi 4 like all other forms of
+    compose, and emit the standard compose messages with the release number
+    in the topic (e.g. compose.24.start or compose.28.start).
+    Here's an example of a message from Fedora 23:
     """
     expected_title = "compose.23.make-updates.start"
     expected_subti = \
@@ -1095,5 +1610,172 @@ class TestMakeUpdatesStarted(Base):
         "topic": "org.fedoraproject.prod.compose.23.make-updates.start"
     }
 
+
+class TestComposeCloudImgBuildComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they had **finished** the cloud image
+    build phase of the make-updates process (which was how we did periodic
+    re-spins of our cloud, atomic, and docker images during the Fedora 21,
+    22 and 23 cycles). From Fedora 24 onwards, these re-spins are produced
+    with Pungi 4 like all other forms of compose, and emit the standard
+    compose messages with the release number in the topic (e.g.
+    compose.24.start or compose.28.start). Here's an example of a message from
+    Fedora 23:
+    """
+    expected_title = "compose.23.cloudimg-build.done"
+    expected_subti = \
+        "the cloudimg-build phase of a F23 make-updates run completed"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/23"
+    expected_objects = set(['23/primary'])
+    msg = {
+        "i": 1,
+        "msg": {
+            "branch": "23",
+            "log": "done"
+        },
+        "timestamp": 1454303707.0,
+        "topic": "org.fedoraproject.prod.compose.23.cloudimg-build.done"
+    }
+
+
+class TestComposeMashAtomicComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they had **started** the Atomic mash
+    phase of the make-updates process (which was how we did periodic
+    re-spins of our cloud, atomic, and docker images during the Fedora 21,
+    22 and 23 cycles). From Fedora 24 onwards, these re-spins are produced
+    with Pungi 4 like all other forms of compose, and emit the standard
+    compose messages with the release number in the topic (e.g.
+    compose.24.start or compose.28.start). Here's an example of a message from
+    Fedora 23:
+    """
+    # yes, 'stop'
+    expected_title = "compose.23.mash-atomic.stop"
+    expected_subti = \
+        "the mash-atomic phase of a F23 make-updates run completed"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/23"
+    expected_objects = set(['23/primary'])
+    msg = {
+        "i": 1,
+        "msg": {
+            "branch": "23",
+            # yes, really 'start', this is what real messages looked like
+            "log": "start"
+        },
+        "timestamp": 1454303707.0,
+        "topic": "org.fedoraproject.prod.compose.23.mash-atomic.stop"
+    }
+
+
+class TestComposeAtomicLoraxComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they had **finished** the Atomic lorax
+    phase of the make-updates process (which was how we did periodic
+    re-spins of our cloud, atomic, and docker images during the Fedora 21,
+    22 and 23 cycles). From Fedora 24 onwards, these re-spins are produced
+    with Pungi 4 like all other forms of compose, and emit the standard
+    compose messages with the release number in the topic (e.g.
+    compose.24.start or compose.28.start). Here's an example of a message from
+    Fedora 23:
+    """
+    expected_title = "compose.23.atomic-lorax.done"
+    expected_subti = \
+        "the atomic-lorax phase of a F23 make-updates run completed"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/23"
+    expected_objects = set(['23/primary'])
+    msg = {
+        "i": 1,
+        "msg": {
+            "branch": "23",
+            "log": "done"
+        },
+        "timestamp": 1454303707.0,
+        "topic": "org.fedoraproject.prod.compose.23.atomic-lorax.done"
+    }
+
+
+class TestComposeCloudImgChecksumStarted(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they had **started** the Cloud image
+    checksum phase of the make-updates process (which was how we did periodic
+    re-spins of our cloud, atomic, and docker images during the Fedora 21,
+    22 and 23 cycles). From Fedora 24 onwards, these re-spins are produced
+    with Pungi 4 like all other forms of compose, and emit the standard
+    compose messages with the release number in the topic (e.g.
+    compose.24.start or compose.28.start). Here's an example of a message from
+    Fedora 23:
+    """
+    expected_title = "compose.23.cloudimg-checksum.start"
+    expected_subti = \
+        "started the cloudimg-checksum phase of a F23 make-updates run"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/23"
+    expected_objects = set(['23/primary'])
+    msg = {
+        "i": 1,
+        "msg": {
+            "branch": "23",
+            "log": "start"
+        },
+        "timestamp": 1454303707.0,
+        "topic": "org.fedoraproject.prod.compose.23.cloudimg-checksum.start"
+    }
+
+
+class TestComposeCloudImgStagingComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    used to produce these messages when they had **finished** the Cloud image
+    staging phase of the make-updates process (which was how we did periodic
+    re-spins of our cloud, atomic, and docker images during the Fedora 21,
+    22 and 23 cycles). From Fedora 24 onwards, these re-spins are produced
+    with Pungi 4 like all other forms of compose, and emit the standard
+    compose messages with the release number in the topic (e.g.
+    compose.24.start or compose.28.start). Here's an example of a message from
+    Fedora 23:
+    """
+    expected_title = "compose.23.cloudimg-staging.done"
+    expected_subti = \
+        "the cloudimg-staging phase of a F23 make-updates run completed"
+    expected_link = \
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/23"
+    expected_objects = set(['23/primary'])
+    msg = {
+        "i": 1,
+        "msg": {
+            "branch": "23",
+            "log": "start"
+        },
+        "timestamp": 1454303707.0,
+        "topic": "org.fedoraproject.prod.compose.23.cloudimg-staging.done"
+    }
+
+## MISCELLANEOUS MESSAGES
+
+
+class TestComposeEPELBetaComplete(Base):
+    """ The `release engineering
+    <https://fedoraproject.org/wiki/ReleaseEngineering>`_ "compose" scripts
+    produce these messages when they have **finished composing** the EPEL beta.
+    """
+    expected_title = "compose.epelbeta.complete"
+    expected_subti = "epelbeta compose completed"
+    expected_link = "https://dl.fedoraproject.org/pub/epel/beta/7/"
+    expected_objects = set(['epelbeta/primary'])
+    msg = {
+        "i": 1,
+        "timestamp": 1344447839.891876,
+        "topic": "org.fedoraproject.prod.compose.epelbeta.complete",
+        "msg": {
+            "log": "done",
+        },
+    }
 
 add_doc(locals())


### PR DESCRIPTION
The tests for the 'compose' message topic were missing rather
a lot of coverage. This commit substantially revises and
extends the tests such that they should hopefully cover just
about all message forms that have existed. This commit does not
change the behaviour of the processor at all, and so some of the
expected values are sort of 'wrong' - they represent what the
processor currently does, even though the newly-added test makes
it clear the processor should probably do something else.
Subsequent commits will improve the processor behaviour, and of
course update the tests where appropriate.

Signed-off-by: Adam Williamson <awilliam@redhat.com>