### PR TITLE
Fix `nodoc` to exclude test class from topic list

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/doc_utilities.py
+++ b/fedmsg_meta_fedora_infrastructure/doc_utilities.py
@@ -158,7 +158,7 @@ def make_topics_doc(output_dir):
                 continue
 
             # You can also exclude a test from the docs with nodoc = True
-            if getattr(cls, 'nodoc', False) is True:
+            if getattr(cls.context, 'nodoc', False) is True:
                 continue
 
             modname = topic.split('.')[0]


### PR DESCRIPTION
It's been documented for a long time that you can set the class
attribute `nodoc` to `True` for a test class, to exclude that
class from appearing in the `topics.rst` file produced by
`make_topics_doc`, which is publicly published as the definitive
list of message topics. However, this has never actually worked
properly, and test classes with `nodoc = True` *do* appear in
the list. This fixes it, by checking the attribute correctly.

Signed-off-by: Adam Williamson <awilliam@redhat.com>