### PR TITLE
Merge the Allpackages processor into the Atomic CI processor

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/centos_ci.py
+++ b/fedmsg_meta_fedora_infrastructure/centos_ci.py
@@ -54,120 +54,127 @@ class AtomicCiProcessor(BaseProcessor):
                 status = 'failed'
             return status
 
-        if '%s.package.ignore' % self.__name__ in msg['topic']:
+        name = self.__name__
+        pipeline_name = self.pipeline_name
+
+        if '%s.allpackages' % name in msg['topic']:
+            name = "ci.pipeline.allpackages"
+            pipeline_name = 'All Packages CI'
+
+        if '%s.package.ignore' % name in msg['topic']:
             tmpl = self._(
                 'Commit "{commit}" of package {ns}/{pkg} is being '
                 'ignored by the {pipeline_name} pipeline on branch {branch}')
 
-        elif '%s.complete' % self.__name__ in msg['topic']:
+        elif '%s.complete' % name in msg['topic']:
             status = _get_status(status)
             tmpl = self._(
                 'Commit "{commit}" of package {ns}/{pkg} {status}'
                 ' the {pipeline_name} pipeline on branch {branch}')
 
-        elif '%s.package.complete' % self.__name__ in msg['topic']:
+        elif '%s.package.complete' % name in msg['topic']:
             status = _get_status(status)
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} {status} building '
                 'in the {pipeline_name} pipeline on branch {branch}')
 
-        elif '%s.package.queued' % self.__name__ in msg['topic']:
+        elif '%s.package.queued' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is queued to be built '
                 'in the {pipeline_name} pipeline on branch {branch}')
 
-        elif '%s.package.running' % self.__name__ in msg['topic']:
+        elif '%s.package.running' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is being built in '
                 'the {pipeline_name} pipeline on branch {branch}')
 
-        elif '%s.package.test.functional.complete' % self.__name__ in msg['topic']:
+        elif '%s.package.test.functional.complete' % name in msg['topic']:
             status = _get_status(status)
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} {status} its '
                 'functional tests in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.package.test.functional.queued' % self.__name__ in msg['topic']:
+        elif '%s.package.test.functional.queued' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is queued for '
                 'functional testing in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.package.test.functional.running' % self.__name__ in msg['topic']:
+        elif '%s.package.test.functional.running' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is running its '
                 'functional tests in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.compose.complete' % self.__name__ in msg['topic']:
+        elif '%s.compose.complete' % name in msg['topic']:
             status = _get_status(status)
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} {status} a '
                 'compose in the {pipeline_name} pipeline on branch {branch}')
 
-        elif '%s.compose.queued' % self.__name__ in msg['topic']:
+        elif '%s.compose.queued' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is queued for a '
                 'compose in the {pipeline_name} pipeline on branch {branch}')
 
-        elif '%s.compose.running' % self.__name__ in msg['topic']:
+        elif '%s.compose.running' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is being part of a '
                 'compose in the {pipeline_name} pipeline on branch {branch}')
 
-        elif '%s.compose.test.integration.complete' % self.__name__ in msg['topic']:
+        elif '%s.compose.test.integration.complete' % name in msg['topic']:
             status = _get_status(status)
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} {status} its tests '
                 'as part of a compose in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.compose.test.integration.queued' % self.__name__ in msg['topic']:
+        elif '%s.compose.test.integration.queued' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is queued for tests '
                 'as part of a compose in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.compose.test.integration.running' % self.__name__ in msg['topic']:
+        elif '%s.compose.test.integration.running' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is being tested as '
                 'part of a compose in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.image.complete' % self.__name__ in msg['topic']:
+        elif '%s.image.complete' % name in msg['topic']:
             status = _get_status(status)
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} {status} being built '
                 'in an image in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.image.queued' % self.__name__ in msg['topic']:
+        elif '%s.image.queued' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is queued to be built '
                 'in an image in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.image.running' % self.__name__ in msg['topic']:
+        elif '%s.image.running' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is being built '
                 'in an image in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.image.test.smoke.complete' % self.__name__ in msg['topic']:
+        elif '%s.image.test.smoke.complete' % name in msg['topic']:
             status = _get_status(status)
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} {status} its tests '
                 'in an image in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.image.test.smoke.queued' % self.__name__ in msg['topic']:
+        elif '%s.image.test.smoke.queued' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is queued to be tested '
                 'in an image in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
-        elif '%s.image.test.smoke.running' % self.__name__ in msg['topic']:
+        elif '%s.image.test.smoke.running' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is being tested '
                 'in an image in the {pipeline_name} pipeline on '
@@ -182,7 +189,7 @@ class AtomicCiProcessor(BaseProcessor):
             pkg=pkg,
             branch=branch,
             status=status,
-            pipeline_name=self.pipeline_name
+            pipeline_name=pipeline_name
         )
 
     def secondary_icon(self, msg, **config):
@@ -226,7 +233,3 @@ class OldAllpackagesCiProcessor(AtomicCiProcessor):
     __obj__ = "CI AllPackages Results"
 
     pipeline_name = 'All Packages CI'
-
-
-class AllpackagesCiProcessor(OldAllpackagesCiProcessor):
-    __name__ = "ci.allpackages.pipeline"

--- a/fedmsg_meta_fedora_infrastructure/tests/centos_ci.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/centos_ci.py
@@ -1084,7 +1084,7 @@ class TestAllPackagesPackageRunning(Base):
     announces that the build of a package is running.
     """
 
-    expected_title = "ci.allpackages.pipeline.package.running"
+    expected_title = "ci.pipeline.allpackages.package.running"
     expected_subti = 'Commit 35cdcb6a of package rpms/gdb is '\
         'being built in the All Packages CI pipeline on branch f28'
     expected_link = "https://jenkins-continuous-infra.apps.ci.centos.org/" \
@@ -1099,7 +1099,7 @@ class TestAllPackagesPackageRunning(Base):
     expected_usernames = set(['jankratochvil'])
     expected_objects = set(
         ['rpms/gdb/35cdcb6a32562b632c075f2fd42793f7492dcdb3/'
-         'f28/package/running'])
+         'f28/allpackages/package/running'])
     msg = {
       "username": None,
       "source_name": "datanommer",
@@ -1107,7 +1107,7 @@ class TestAllPackagesPackageRunning(Base):
       "timestamp": 1522054091.0,
       "msg_id": "2018-cfb9a40e-3220-4dcf-a5aa-270a6cee975c",
       "crypto": "x509",
-      "topic": "org.centos.prod.ci.allpackages.pipeline.package.running",
+      "topic": "org.centos.prod.ci.pipeline.allpackages.package.running",
       "headers": {},
       "source_version": "0.8.2",
       "msg": {
@@ -1122,7 +1122,7 @@ class TestAllPackagesPackageRunning(Base):
         "namespace": "rpms",
         "CI_NAME": "upstream-fedora-f28-pipeline",
         "repo": "gdb",
-        "topic": "org.centos.prod.allpackages.pipeline.package.running",
+        "topic": "org.centos.prod.ci.pipeline.allpackages.package.running",
         "status": "SUCCESS",
         "branch": "f28",
         "test_guidance": "''",
@@ -1137,7 +1137,7 @@ class TestAllPackagesCompleteSuccess(Base):
     on a package.
     """
 
-    expected_title = "ci.allpackages.pipeline.complete"
+    expected_title = "ci.pipeline.allpackages.complete"
     expected_subti = 'Commit "35cdcb6a" of package rpms/gdb passed the ' \
         'All Packages CI pipeline on branch f28'
     expected_link = "https://jenkins-continuous-infra.apps.ci.centos.org/" \
@@ -1153,7 +1153,7 @@ class TestAllPackagesCompleteSuccess(Base):
     expected_objects = set(
         ['rpms/gdb/'
          '35cdcb6a32562b632c075f2fd42793f7492dcdb3/'
-         'f28/complete'])
+         'f28/allpackages/complete'])
     msg = {
       "username": None,
       "source_name": "datanommer",
@@ -1161,7 +1161,7 @@ class TestAllPackagesCompleteSuccess(Base):
       "timestamp": 1522055492.0,
       "msg_id": "2018-1436f172-aa90-49f2-9ff0-9b34608f38e8",
       "crypto": "x509",
-      "topic": "org.centos.prod.ci.allpackages.pipeline.complete",
+      "topic": "org.centos.prod.ci.pipeline.allpackages.complete",
       "headers": {},
       "source_version": "0.8.2",
       "msg": {
@@ -1176,7 +1176,7 @@ class TestAllPackagesCompleteSuccess(Base):
         "namespace": "rpms",
         "CI_NAME": "upstream-fedora-f28-pipeline",
         "repo": "gdb",
-        "topic": "org.centos.prod.allpackages.pipeline.complete",
+        "topic": "org.centos.prod.ci.pipeline.allpackages.complete",
         "status": "SUCCESS",
         "branch": "f28",
         "test_guidance": "''",

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,6 @@ entry_points = {
         "pdc=fedmsg_meta_fedora_infrastructure.pdc:PDCProcessor",
         "mbs=fedmsg_meta_fedora_infrastructure.mbs:MBSProcessor",
         "old_allpackages_ci=fedmsg_meta_fedora_infrastructure.centos_ci:OldAllpackagesCiProcessor",
-        "allpackages_ci=fedmsg_meta_fedora_infrastructure.centos_ci:AllpackagesCiProcessor",
         "ci=fedmsg_meta_fedora_infrastructure.centos_ci:AtomicCiProcessor",
         "waiverdb=fedmsg_meta_fedora_infrastructure.waiverdb:WaiverDBProcessor",
         "gw=fedmsg_meta_fedora_infrastructure.greenwave:GreenwaveProcessor",


### PR DESCRIPTION
By itself this is not ideal, we are using the same processor for messages coming
from two different CI pipelines running in the ci.centos.org infrastructure.
However, we do not have really the choice, the first pipeline deployed there
is sending org.centos.prod/stage.ci.pipeline.<action> while the allpackages
pipeline is now sending messages of the type:
org.centos.prod/stage.ci.pipeline.allpackages and this is caught by the
Atomic CI processor.

So we had two ways to fix this:
- adjust the topic sent by the Atomic CI pipeline to include something like
  atomic_ci where the other pipeline is using 'allpackages'
- hack the processor to support both the atomic_ci and the allpackages format

Since we aim at being backward compatible, the second step was needed anyway
to support old and potentially new format of the messages sent by the atomic_ci
pipeline.
So since we do the second fix anyway, it is just as easy to not adjust the topic
sent by the Atomic CI pipeline.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>