### PR TITLE
Fixing typo and Greenwave msg link params order

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/greenwave.py
+++ b/fedmsg_meta_fedora_infrastructure/greenwave.py
@@ -32,17 +32,17 @@ class GreenwaveProcessor(BaseProcessor):
 
     @staticmethod
     def satisfied(msg):
-        try:
-            # https://pagure.io/greenwave/pull-request/100
-            return msg['msg']['policies_satisfied']
-        except KeyError:
-            return msg['msg']['policies_satisified']
+        return msg['msg']['policies_satisfied']
 
     def link(self, msg, **config):
         subject = msg['msg']['subject']
         if subject:
             base = "https://taskotron.fedoraproject.org/resultsdb/results"
-            query = urlencode(msg['msg']['subject'][0])
+            # we want to be sure that we always have the same parameter order
+            query = urlencode(sorted(
+                [(k, v) for k, v in msg['msg']['subject'][0].items()],
+                key=lambda tup: tup[0]
+            ))
             return base + "?" + query
 
     def subtitle(self, msg, **config):

--- a/fedmsg_meta_fedora_infrastructure/tests/greenwave.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/greenwave.py
@@ -52,7 +52,7 @@ class TestGreenwaveDecisionChange(Base):
         "crypto": "x509",
         "topic": "org.fedoraproject.prod.greenwave.decision.update",
         "msg": {
-            "policies_satisified": True,
+            "policies_satisfied": True,
             "decision_context": "bodhi_update_push_stable",
             "product_version": "fedora-27",
             "applicable_policies": [
@@ -67,7 +67,7 @@ class TestGreenwaveDecisionChange(Base):
             ],
             "summary": "all required tests passed",
             "previous": {
-                "policies_satisified": False,
+                "policies_satisfied": False,
                 "summary": "1 of 2 required tests not found",
                 "unsatisfied_requirements": [
                     {


### PR DESCRIPTION
Fixing "policies_satisified" typo.
And adding some code to be sure that the parameters in the link in
the Greenwave message will always have the same sorting so that
the test will always pass.