### PR TITLE
Update releng.atomic.twoweek fedmsg doc with multi-arch content

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/releng.py
+++ b/fedmsg_meta_fedora_infrastructure/releng.py
@@ -29,7 +29,10 @@ class RelengProcessor(BaseProcessor):
     __icon__ = "https://apps.fedoraproject.org/img/icons/atomic.png"
 
     def subtitle(self, msg, **config):
-        release = msg['msg']['atomic_raw'].get('release', '')
+        if 'x86_64' in msg['msg'].keys():
+            release = msg['msg']['x86_64']['atomic_raw'].get('release', '')
+        else:
+            release = msg['msg']['atomic_raw'].get('release', '')
         if msg['topic'].endswith('.releng.atomic.twoweek.begin'):
             tmpl = self._("Release engineering scripts started evaluating a "
                           "new set of builds for a Fedora {release} Atomic "
@@ -49,7 +52,10 @@ class RelengProcessor(BaseProcessor):
         return self.__icon__
 
     def objects(self, msg, **config):
-        return set([
-            "%s/%s" % (msg['msg'][key]['release'], key)
-            for key in msg['msg'] if key.startswith('atomic_')
-        ])
+        if 'x86_64' in msg['msg'].keys():
+            return set(msg['msg'].keys())
+        else:
+            return set([
+                "%s/%s" % (msg['msg'][key]['release'], key)
+                for key in msg['msg'] if key.startswith('atomic_')
+            ])

--- a/fedmsg_meta_fedora_infrastructure/tests/releng.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/releng.py
@@ -29,10 +29,280 @@ from .common import add_doc
 class TestTwoWeekAtomicBegin(Base):
     """ As one of the final steps in the `two week atomic
     <https://fedoraproject.org/wiki/Changes/Two_Week_Atomic>`_ process, there
+    is a `release engineering script
+    <https://pagure.io/releng/blob/master/f/scripts/push-two-week-atomic.py>`_ that
+    runs to perform the release.
+
+    During the two week script run, it fetches AtomicHost artifacts detail
+    for given pungi compose ID using `fedfind
+    <https://pagure.io/fedora-qa/fedfind/>`_ . After getting image
+    artifacts and ostree commit information successfully for all supported
+    architectures, it sends this fedmsg indicating that Two Week release process has started.
+    """
+
+    expected_title = "releng.atomic.twoweek.begin"
+    expected_subti = "Release engineering scripts started evaluating a " + \
+        "new set of builds for a Fedora 28 Atomic Host release"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/atomic.png"
+    expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/atomic.png"
+    expected_link = "https://download.fedoraproject.org/pub/alt/atomic/stable/"
+    expected_objects = set([u'aarch64', u'x86_64', u'ppc64le'])
+
+    msg = {
+        u'timestamp': 1444939709.0,
+        u'topic': u'org.fedoraproject.prod.releng.atomic.twoweek.begin',
+        u'msg': {
+            u'aarch64': {
+                u'atomic_dvd_ostree': {
+                    u'name': u'Fedora-AtomicHost-ostree-aarch64-28-20180515.1.iso',
+                    u'image_name': u'Fedora-AtomicHost-ostree-aarch64-28-20180515.1.iso',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'aarch64/iso/Fedora-AtomicHost-ostree-aarch64-28-20180515.1.iso',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 988649472
+                },
+                u'atomic_qcow2': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.aarch64.qcow2',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/'
+                    'AtomicHost/aarch64/images/Fedora-AtomicHost-28-20180515.1.aarch64.qcow2',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 621911040
+                },
+                u'atomic_raw': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.aarch64.raw.xz',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/'
+                    'AtomicHost/aarch64/images/Fedora-AtomicHost-28-20180515.1.aarch64.raw.xz',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 396619232
+                }
+            },
+            u'x86_64': {
+                u'atomic_dvd_ostree': {
+                    u'name': u'Fedora-AtomicHost-ostree-x86_64-28-20180515.1.iso',
+                    u'image_name': u'Fedora-AtomicHost-ostree-x86_64-28-20180515.1.iso',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'x86_64/iso/Fedora-AtomicHost-ostree-x86_64-28-20180515.1.iso',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 1034944512
+                },
+                u'atomic_qcow2': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.x86_64.qcow2',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/'
+                    'AtomicHost/x86_64/images/Fedora-AtomicHost-28-20180515.1.x86_64.qcow2',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 635537920
+                },
+                u'atomic_raw': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.x86_64.raw.xz',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/'
+                    'AtomicHost/x86_64/images/Fedora-AtomicHost-28-20180515.1.x86_64.raw.xz',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 457994952
+                },
+                u'atomic_vagrant_libvirt': {
+                    u'name': u'Fedora-AtomicHost-Vagrant-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-Vagrant-28-20180515.1.x86_64.vagrant-libvirt.box',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'x86_64/images/Fedora-AtomicHost-Vagrant-28-20180515.1.x86_64.vagrant-libvirt.box',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 603786982
+                },
+                u'atomic_vagrant_virtualbox': {
+                    u'name': u'Fedora-AtomicHost-Vagrant-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-Vagrant-28-20180515.1.x86_64.vagrant-virtualbox.box',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'x86_64/images/Fedora-AtomicHost-Vagrant-28-20180515.1.x86_64.vagrant-virtualbox.box',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 617984000
+                }
+            },
+            u'ppc64le': {
+                u'atomic_dvd_ostree': {
+                    u'name': u'Fedora-AtomicHost-ostree-ppc64le-28-20180515.1.iso',
+                    u'image_name': u'Fedora-AtomicHost-ostree-ppc64le-28-20180515.1.iso',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'ppc64le/iso/Fedora-AtomicHost-ostree-ppc64le-28-20180515.1.iso',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 1036103680
+                },
+                u'atomic_qcow2': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.ppc64le.qcow2',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'ppc64le/images/Fedora-AtomicHost-28-20180515.1.ppc64le.qcow2',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 636539904
+                },
+                u'atomic_raw': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.ppc64le.raw.xz',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'ppc64le/images/Fedora-AtomicHost-28-20180515.1.ppc64le.raw.xz',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 411513572
+                }
+            }
+        }
+    }
+
+
+class TestTwoWeekAtomicComplete(Base):
+    """ As one of the final steps in the `two week atomic
+    <https://fedoraproject.org/wiki/Changes/Two_Week_Atomic>`_ process, there
+    is a `release engineering script
+    <https://pagure.io/releng/blob/master/f/scripts/push-two-week-atomic.py>`_ that
+    runs to perform the release.
+
+    During this phase of two week script run, static delta gets generated
+    from previous Two Week release. Later ref in repo gets updated with
+    latest ostree commit information for each arch, followed by Two Week
+    release announcement email.
+    On successful completion of all steps, it sends this fedmsg indicating that
+    Two Week release process has completed and fedora website atomic page
+    should be updated with latest download links.
+    """
+
+    expected_title = "releng.atomic.twoweek.complete"
+    expected_subti = "A new release of Fedora 28 Atomic Host is ready"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/atomic.png"
+    expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/atomic.png"
+    expected_link = "https://download.fedoraproject.org/pub/alt/atomic/stable/"
+    expected_objects = set([u'aarch64', u'x86_64', u'ppc64le'])
+
+    msg = {
+        u'timestamp': 1444939709.0,
+        u'topic': u'org.fedoraproject.prod.releng.atomic.twoweek.complete',
+        u'msg': {
+            u'aarch64': {
+                u'atomic_dvd_ostree': {
+                    u'name': u'Fedora-AtomicHost-ostree-aarch64-28-20180515.1.iso',
+                    u'image_name': u'Fedora-AtomicHost-ostree-aarch64-28-20180515.1.iso',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'aarch64/iso/Fedora-AtomicHost-ostree-aarch64-28-20180515.1.iso',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 988649472
+                },
+                u'atomic_qcow2': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.aarch64.qcow2',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/'
+                    'AtomicHost/aarch64/images/Fedora-AtomicHost-28-20180515.1.aarch64.qcow2',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 621911040
+                },
+                u'atomic_raw': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.aarch64.raw.xz',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/'
+                    'AtomicHost/aarch64/images/Fedora-AtomicHost-28-20180515.1.aarch64.raw.xz',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 396619232
+                }
+            },
+            u'x86_64': {
+                u'atomic_dvd_ostree': {
+                    u'name': u'Fedora-AtomicHost-ostree-x86_64-28-20180515.1.iso',
+                    u'image_name': u'Fedora-AtomicHost-ostree-x86_64-28-20180515.1.iso',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'x86_64/iso/Fedora-AtomicHost-ostree-x86_64-28-20180515.1.iso',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 1034944512
+                },
+                u'atomic_qcow2': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.x86_64.qcow2',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/'
+                    'AtomicHost/x86_64/images/Fedora-AtomicHost-28-20180515.1.x86_64.qcow2',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 635537920
+                },
+                u'atomic_raw': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.x86_64.raw.xz',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/'
+                    'AtomicHost/x86_64/images/Fedora-AtomicHost-28-20180515.1.x86_64.raw.xz',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 457994952
+                },
+                u'atomic_vagrant_libvirt': {
+                    u'name': u'Fedora-AtomicHost-Vagrant-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-Vagrant-28-20180515.1.x86_64.vagrant-libvirt.box',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'x86_64/images/Fedora-AtomicHost-Vagrant-28-20180515.1.x86_64.vagrant-libvirt.box',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 603786982
+                },
+                u'atomic_vagrant_virtualbox': {
+                    u'name': u'Fedora-AtomicHost-Vagrant-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-Vagrant-28-20180515.1.x86_64.vagrant-virtualbox.box',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'x86_64/images/Fedora-AtomicHost-Vagrant-28-20180515.1.x86_64.vagrant-virtualbox.box',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 617984000
+                }
+            },
+            u'ppc64le': {
+                u'atomic_dvd_ostree': {
+                    u'name': u'Fedora-AtomicHost-ostree-ppc64le-28-20180515.1.iso',
+                    u'image_name': u'Fedora-AtomicHost-ostree-ppc64le-28-20180515.1.iso',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'ppc64le/iso/Fedora-AtomicHost-ostree-ppc64le-28-20180515.1.iso',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 1036103680
+                },
+                u'atomic_qcow2': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.ppc64le.qcow2',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'ppc64le/images/Fedora-AtomicHost-28-20180515.1.ppc64le.qcow2',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 636539904
+                },
+                u'atomic_raw': {
+                    u'name': u'Fedora-AtomicHost-28-20180515.1',
+                    u'image_name': u'Fedora-AtomicHost-28-20180515.1.ppc64le.raw.xz',
+                    u'image_url': u'/pub/alt/atomic/stable/Fedora-Atomic-28-20180515.1/AtomicHost/'
+                    'ppc64le/images/Fedora-AtomicHost-28-20180515.1.ppc64le.raw.xz',
+                    u'release': u'28',
+                    u'compose_id': u'Fedora-Atomic-28-20180515.1',
+                    u'size': 411513572
+                }
+            }
+        }
+    }
+
+
+class LegacyTestTwoWeekAtomicBegin(Base):
+    """ As one of the final steps in the `two week atomic
+    <https://fedoraproject.org/wiki/Changes/Two_Week_Atomic>`_ process, there
     is a release engineering script (the green box in `this diagram
     <https://fedoraproject.org/wiki/File:TwoWeekAtomic-Overview-v2.png>`_) that
     determines if the builds of Fedora Atomic Host are fit for release.
-
     If it determines that the builds are ready (usually by cross-referencing
     test results from `autocloud <https://apps.fedoraproject.org/autocloud>`_),
     then it publishes one of these messages, indicating that the website should
@@ -69,13 +339,12 @@ class TestTwoWeekAtomicBegin(Base):
     }
 
 
-class TestTwoWeekAtomicComplete(Base):
+class LegacyTestTwoWeekAtomicComplete(Base):
     """ As one of the final steps in the `two week atomic
     <https://fedoraproject.org/wiki/Changes/Two_Week_Atomic>`_ process, there
     is a release engineering script (the green box in `this diagram
     <https://fedoraproject.org/wiki/File:TwoWeekAtomic-Overview-v2.png>`_) that
     determines if the builds of Fedora Atomic Host are fit for release.
-
     If it determines that the builds are ready (usually by cross-referencing
     test results from `autocloud <https://apps.fedoraproject.org/autocloud>`_),
     then it publishes one of these messages, indicating that the website should
@@ -108,7 +377,7 @@ class TestTwoWeekAtomicComplete(Base):
                 "name": "Fedora-Cloud-Atomic-Raw"
             }
         }
-    }
+}
 
 
 add_doc(locals())


### PR DESCRIPTION
We have updated releng push-two-week-atomic script to
send multi-arch information as well in fedmsg.
Link - https://pagure.io/releng/c/ff2f2a5e035fa41507553acbc4f2fa15cc1873f5?branch=master

Signed-off-by: Sinny Kumari <sinny@redhat.com>