### PR TITLE
Add container pipeline topics

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/centos_ci.py
+++ b/fedmsg_meta_fedora_infrastructure/centos_ci.py
@@ -61,6 +61,10 @@ class AtomicCiProcessor(BaseProcessor):
             name = "ci.pipeline.allpackages"
             pipeline_name = 'All Packages CI'
 
+        elif '%s.container' % name in msg['topic']:
+            name = "ci.pipeline.container"
+            pipeline_name = 'Container CI'
+
         if '%s.package.ignore' % name in msg['topic']:
             tmpl = self._(
                 'Commit "{commit}" of package {ns}/{pkg} is being '
@@ -104,6 +108,25 @@ class AtomicCiProcessor(BaseProcessor):
         elif '%s.package.test.functional.running' % name in msg['topic']:
             tmpl = self._(
                 'Commit {commit} of package {ns}/{pkg} is running its '
+                'functional tests in the {pipeline_name} pipeline on '
+                'branch {branch}')
+
+        elif '%s.container.test.functional.complete' % name in msg['topic']:
+            status = _get_status(status)
+            tmpl = self._(
+                'Commit {commit} of container {ns}/{pkg} {status} its '
+                'functional tests in the {pipeline_name} pipeline on '
+                'branch {branch}')
+
+        elif '%s.container.test.functional.queued' % name in msg['topic']:
+            tmpl = self._(
+                'Commit {commit} of container {ns}/{pkg} is queued for '
+                'functional testing in the {pipeline_name} pipeline on '
+                'branch {branch}')
+
+        elif '%s.container.test.functional.running' % name in msg['topic']:
+            tmpl = self._(
+                'Commit {commit} of container {ns}/{pkg} is running its '
                 'functional tests in the {pipeline_name} pipeline on '
                 'branch {branch}')
 
@@ -233,3 +256,16 @@ class OldAllpackagesCiProcessor(AtomicCiProcessor):
     __obj__ = "CI AllPackages Results"
 
     pipeline_name = 'All Packages CI'
+
+class OldContainerCiProcessor(AtomicCiProcessor):
+    topic_prefix_re = 'org\\.centos\\.(dev|stage|prod)'
+
+    __name__ = "container.pipeline"
+    __description__ = "The CentOS Continuous Integration pipeline for " \
+        "containers"
+    __link__ = "http://ci.centos.org/"
+    __icon__ = "https://ci.centos.org/static/ec6de755/images/headshot.png"
+    __docs__ = "https://github.com/CentOS-PaaS-SIG/ci-pipeline/"
+    __obj__ = "CI Container Results"
+
+    pipeline_name = 'Container CI'

--- a/fedmsg_meta_fedora_infrastructure/centos_ci.py
+++ b/fedmsg_meta_fedora_infrastructure/centos_ci.py
@@ -62,7 +62,7 @@ class AtomicCiProcessor(BaseProcessor):
             pipeline_name = 'All Packages CI'
 
         elif '%s.container' % name in msg['topic']:
-            name = "ci.pipeline.container"
+            name = "ci.pipeline.container-pr"
             pipeline_name = 'Container CI'
 
         if '%s.package.ignore' % name in msg['topic']:
@@ -75,6 +75,10 @@ class AtomicCiProcessor(BaseProcessor):
             tmpl = self._(
                 'Commit "{commit}" of package {ns}/{pkg} {status}'
                 ' the {pipeline_name} pipeline on branch {branch}')
+            if pipeline_name == 'Container CI':
+                tmpl = self._(
+                    'Commit "{commit}" of container {ns}/{pkg} {status}'
+                    ' the {pipeline_name} pipeline on branch {branch}')
 
         elif '%s.package.complete' % name in msg['topic']:
             status = _get_status(status)

--- a/fedmsg_meta_fedora_infrastructure/tests/centos_ci.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/centos_ci.py
@@ -1192,20 +1192,21 @@ class TestContainerTestRunning(Base):
 
     expected_title = "ci.pipeline.container-pr.container.test.functional.running"
     expected_subti = 'Commit 35cdcb6a of container container/tools is '\
-        'being built in the Container CI pipeline on master'
+        'running its functional tests in the Container CI pipeline '\
+        'on branch master'
     expected_link = "https://jenkins-continuous-infra.apps.ci.centos.org/" \
         "blue/organizations/jenkins/fedcontainer-rawhide-pr-pipeline/detail/" \
         "fedcontainer-rawhide-pr-pipeline/50/pipeline/"
     expected_icon = "https://ci.centos.org/static/ec6de755/images/" \
         "headshot.png"
     expected_secondary_icon = 'https://seccdn.libravatar.org/avatar/'\
-        '4a5e1bf0da6d9dfba3e0dc300fe58f6fc7d064df703eafbf2502dd900f69c1b4'\
+        'b13ed9018e915cdb42f59c1435e3d55bcac2f4d9843cda1a1d978dc6cad09968'\
         '?s=64&d=retro'
     expected_packages = set([])
     expected_usernames = set(['cverna'])
     expected_objects = set(
         ['container/tools/35cdcb6a32562b632c075f2fd42793f7492dcdb3/'
-         'master/container/container/test/functional/running'])
+         'master/container-pr/container/test/functional/running'])
     msg = {
       "username": None,
       "source_name": "datanommer",
@@ -1250,7 +1251,7 @@ class TestContainerCompleteSuccess(Base):
     expected_icon = "https://ci.centos.org/static/ec6de755/images/" \
         "headshot.png"
     expected_secondary_icon = 'https://seccdn.libravatar.org/avatar/'\
-        '4a5e1bf0da6d9dfba3e0dc300fe58f6fc7d064df703eafbf2502dd900f69c1b4'\
+        'b13ed9018e915cdb42f59c1435e3d55bcac2f4d9843cda1a1d978dc6cad09968'\
         '?s=64&d=retro'
     expected_packages = set([])
     expected_usernames = set(['cverna'])

--- a/fedmsg_meta_fedora_infrastructure/tests/centos_ci.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/centos_ci.py
@@ -1185,6 +1185,108 @@ class TestAllPackagesCompleteSuccess(Base):
     }
 
 
+class TestContainerTestRunning(Base):
+    """ These messages are published when the Container CI pipeline
+    announces that the test of a container is running.
+    """
+
+    expected_title = "ci.pipeline.container-pr.container.test.functional.running"
+    expected_subti = 'Commit 35cdcb6a of container container/tools is '\
+        'being built in the Container CI pipeline on master'
+    expected_link = "https://jenkins-continuous-infra.apps.ci.centos.org/" \
+        "blue/organizations/jenkins/fedcontainer-rawhide-pr-pipeline/detail/" \
+        "fedcontainer-rawhide-pr-pipeline/50/pipeline/"
+    expected_icon = "https://ci.centos.org/static/ec6de755/images/" \
+        "headshot.png"
+    expected_secondary_icon = 'https://seccdn.libravatar.org/avatar/'\
+        '4a5e1bf0da6d9dfba3e0dc300fe58f6fc7d064df703eafbf2502dd900f69c1b4'\
+        '?s=64&d=retro'
+    expected_packages = set([])
+    expected_usernames = set(['cverna'])
+    expected_objects = set(
+        ['container/tools/35cdcb6a32562b632c075f2fd42793f7492dcdb3/'
+         'master/container/container/test/functional/running'])
+    msg = {
+      "username": None,
+      "source_name": "datanommer",
+      "i": 1,
+      "timestamp": 1522054091.0,
+      "msg_id": "2018-cfb9a40e-3220-4dcf-a5aa-270a6cee975c",
+      "crypto": "x509",
+      "topic": "org.centos.prod.ci.pipeline.container-pr.container.test.functional.running",
+      "headers": {},
+      "source_version": "0.8.2",
+      "msg": {
+        "CI_TYPE": "custom",
+        "build_id": "50",
+        "username": "cverna",
+        "rev": "35cdcb6a32562b632c075f2fd42793f7492dcdb3",
+        "message-content": "",
+        "build_url": "https://jenkins-continuous-infra.apps.ci.centos.org/blue/organizations/jenkins/fedcontainer-rawhide-pr-pipeline/detail/fedcontainer-rawhide-pr-pipeline/50/pipeline/",
+        "namespace": "container",
+        "CI_NAME": "fedcontainer-rawhide-pr-pipeline",
+        "repo": "tools",
+        "topic": "org.centos.prod.ci.pipeline.container-pr.container.test.functional.running",
+        "status": "SUCCESS",
+        "branch": "master",
+        "test_guidance": "''",
+        "ref": "x86_64"
+      }
+    }
+
+
+class TestContainerCompleteSuccess(Base):
+    """ These messages are published when the Container CI pipeline
+    announces having completed successfully running the entire pipeline
+    on a container.
+    """
+
+    expected_title = "ci.pipeline.container-pr.complete"
+    expected_subti = 'Commit "35cdcb6a" of container container/tools passed the ' \
+        'Container CI pipeline on branch master'
+    expected_link = "https://jenkins-continuous-infra.apps.ci.centos.org/" \
+        "blue/organizations/jenkins/fedcontainer-rawhide-pr-pipeline/detail/" \
+        "fedcontainer-rawhide-pr-pipeline/50/pipeline/"
+    expected_icon = "https://ci.centos.org/static/ec6de755/images/" \
+        "headshot.png"
+    expected_secondary_icon = 'https://seccdn.libravatar.org/avatar/'\
+        '4a5e1bf0da6d9dfba3e0dc300fe58f6fc7d064df703eafbf2502dd900f69c1b4'\
+        '?s=64&d=retro'
+    expected_packages = set([])
+    expected_usernames = set(['cverna'])
+    expected_objects = set(
+        ['container/tools/'
+         '35cdcb6a32562b632c075f2fd42793f7492dcdb3/'
+         'master/container/complete'])
+    msg = {
+      "username": None,
+      "source_name": "datanommer",
+      "i": 1,
+      "timestamp": 1522055492.0,
+      "msg_id": "2018-1436f172-aa90-49f2-9ff0-9b34608f38e8",
+      "crypto": "x509",
+      "topic": "org.centos.prod.ci.pipeline.container-pr.complete",
+      "headers": {},
+      "source_version": "0.8.2",
+      "msg": {
+        "CI_TYPE": "custom",
+        "build_id": "50",
+        "username": "cverna",
+        "rev": "35cdcb6a32562b632c075f2fd42793f7492dcdb3",
+        "message-content": "",
+        "build_url": "https://jenkins-continuous-infra.apps.ci.centos.org/blue/organizations/jenkins/fedcontainer-rawhide-pr-pipeline/detail/fedcontainer-rawhide-pr-pipeline/50/pipeline/",
+        "namespace": "container",
+        "CI_NAME": "upstream-fedora-f28-pipeline",
+        "repo": "tools",
+        "topic": "org.centos.prod.ci.pipeline.container-pr.complete",
+        "status": "SUCCESS",
+        "branch": "master",
+        "test_guidance": "''",
+        "ref": "x86_64"
+      }
+    }
+
+
 add_doc(locals())
 
 

--- a/fedmsg_meta_fedora_infrastructure/tests/centos_ci.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/centos_ci.py
@@ -1257,7 +1257,7 @@ class TestContainerCompleteSuccess(Base):
     expected_objects = set(
         ['container/tools/'
          '35cdcb6a32562b632c075f2fd42793f7492dcdb3/'
-         'master/container/complete'])
+         'master/container-pr/complete'])
     msg = {
       "username": None,
       "source_name": "datanommer",

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ entry_points = {
         "pdc=fedmsg_meta_fedora_infrastructure.pdc:PDCProcessor",
         "mbs=fedmsg_meta_fedora_infrastructure.mbs:MBSProcessor",
         "old_allpackages_ci=fedmsg_meta_fedora_infrastructure.centos_ci:OldAllpackagesCiProcessor",
+        "old_container_ci=fedmsg_meta_fedora_infrastructure.centos_ci:OldContainerCiProcessor",
         "ci=fedmsg_meta_fedora_infrastructure.centos_ci:AtomicCiProcessor",
         "waiverdb=fedmsg_meta_fedora_infrastructure.waiverdb:WaiverDBProcessor",
         "gw=fedmsg_meta_fedora_infrastructure.greenwave:GreenwaveProcessor",


### PR DESCRIPTION
There is a new pipeline that is apples to apples with the all packages fedora pipeline, but for the container namespace. Because it is just on containers, there is only interesting stage in this pipeline (the functional tests). I hope to turn the messages on for these soon, so I am hoping to add them to fedmsg_meta.