### PR TITLE
Bodhi schema compliance + more

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/tests/bodhi.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/bodhi.py
@@ -1267,18 +1267,18 @@ class TestBodhiRepoDone(Base):
     expected_objects = set(['repos/f29-updates-testing'])
 
     msg = {
-      "username": "amqp-bridge", 
-      "source_name": "datanommer", 
-      "i": 185742, 
-      "timestamp": 1559883894.0, 
-      "msg_id": "2019-139ee383-4b15-4ba5-87c1-e366c182bb64", 
-      "crypto": "x509", 
-      "topic": "org.fedoraproject.prod.bodhi.repo.done", 
-      "headers": {}, 
-      "source_version": "0.9.0", 
+      "username": "amqp-bridge",
+      "source_name": "datanommer",
+      "i": 185742,
+      "timestamp": 1559883894.0,
+      "msg_id": "2019-139ee383-4b15-4ba5-87c1-e366c182bb64",
+      "crypto": "x509",
+      "topic": "org.fedoraproject.prod.bodhi.repo.done",
+      "headers": {},
+      "source_version": "0.9.0",
       "msg": {
-        "repo": "f29-updates-testing", 
-        "path": "/mnt/koji/compose/updates/Fedora-29-updates-testing-20190607.0", 
+        "repo": "f29-updates-testing",
+        "path": "/mnt/koji/compose/updates/Fedora-29-updates-testing-20190607.0",
         "agent": "releng"
       }
     }

--- a/fedmsg_meta_fedora_infrastructure/tests/bodhi.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/bodhi.py
@@ -2346,10 +2346,13 @@ mash_list = """
 - dnf-plugins-core-0.1.9-1.fc22
 """
 
-class TestBodhiMashKickooff(Base):
+class TestLegacyBodhi2MasherStart(Base):
     """ This message is published by an admin when they send a request to
     the `Bodhi2 <https://bodhi.fedoraproject.org>`_ backend, telling it
-    to start a mash.
+    to start a mash. This is how messages looked before Bodhi commit
+    3b655f23 , which changed the message from including a dict of updates
+    to including a dict of composes. The first release with the change
+    was 3.2.0.
     """
     expected_title = "bodhi.masher.start"
     expected_subti = "ralph requested a mash of 20 updates"
@@ -2435,6 +2438,197 @@ class TestBodhiMashKickooff(Base):
             ],
             "agent": "ralph"
         }
+    }
+
+
+class TestLegacyBodhi320MasherStart(Base):
+    """ This message is published by an admin when they send a request to
+    the `Bodhi 3.2.0+ <https://bodhi.fedoraproject.org>`_ backend, telling it
+    to start a mash.
+    """
+    expected_title = "bodhi.masher.start"
+    expected_subti = "releng requested a mash of some updates"
+    expected_link = "https://bodhi.fedoraproject.org"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/bodhi.png"
+    expected_secondary_icon = "https://seccdn.libravatar.org/avatar/" + \
+        "05b5fce36707d3f962a8dc03094e41028ac3e765c8c2e182eab96228013ec9c9" + \
+        "?s=64&d=retro"
+    expected_usernames = set(['releng'])
+    expected_packages = set([])
+    expected_objects = set([])
+    msg = {
+      "username": "apache",
+      "source_name": "datanommer",
+      "i": 1,
+      "timestamp": 1559001608.0,
+      "msg_id": "2019-13d8e80d-34a3-49d6-9d46-b465d891535d",
+      "crypto": "x509",
+      "topic": "org.fedoraproject.prod.bodhi.masher.start",
+      "headers": {},
+      "source_version": "0.9.0",
+      "msg": {
+        "resume": False,
+        "api_version": 2,
+        "agent": "releng",
+        "composes": [
+          {
+            "security": True,
+            "release_id": 28,
+            "request": "stable",
+            "content_type": "rpm"
+          },
+          {
+            "security": True,
+            "release_id": 23,
+            "request": "stable",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 21,
+            "request": "stable",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 8,
+            "request": "stable",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 28,
+            "request": "testing",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 8,
+            "request": "testing",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 23,
+            "request": "testing",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 21,
+            "request": "testing",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 10,
+            "request": "testing",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 29,
+            "request": "testing",
+            "content_type": "module"
+          },
+          {
+            "security": False,
+            "release_id": 24,
+            "request": "testing",
+            "content_type": "module"
+          }
+        ]
+      }
+    }
+
+
+class TestBodhi4ComposerStart(Base):
+    """ This message is published by an admin when they send a request to
+    the `Bodhi 4+ <https://bodhi.fedoraproject.org>`_ backend, telling it
+    to start a mash. It is exactly like bodhi.masher.start from Bodhi
+    3.2.0+, just with the name changed to bodhi.composer.start.
+    """
+    expected_title = "bodhi.composer.start"
+    expected_subti = "releng requested a mash of some updates"
+    expected_link = "https://bodhi.fedoraproject.org"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/bodhi.png"
+    expected_secondary_icon = "https://seccdn.libravatar.org/avatar/" + \
+        "05b5fce36707d3f962a8dc03094e41028ac3e765c8c2e182eab96228013ec9c9" + \
+        "?s=64&d=retro"
+    expected_usernames = set(['releng'])
+    expected_packages = set([])
+    expected_objects = set([])
+    msg = {
+      "username": "amqp-bridge",
+      "source_name": "datanommer",
+      "i": 226693,
+      "timestamp": 1561593605.0,
+      "msg_id": "2019-d3041ae5-2b13-4269-944e-cee4d8238c87",
+      "crypto": "x509",
+      "topic": "org.fedoraproject.prod.bodhi.composer.start",
+      "headers": {},
+      "source_version": "0.9.0",
+      "msg": {
+        "resume": False,
+        "api_version": 2,
+        "agent": "releng",
+        "composes": [
+          {
+            "security": True,
+            "release_id": 8,
+            "request": "stable",
+            "content_type": "rpm"
+          },
+          {
+            "security": True,
+            "release_id": 23,
+            "request": "stable",
+            "content_type": "rpm"
+          },
+          {
+            "security": True,
+            "release_id": 28,
+            "request": "stable",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 29,
+            "request": "stable",
+            "content_type": "module"
+          },
+          {
+            "security": False,
+            "release_id": 24,
+            "request": "stable",
+            "content_type": "module"
+          },
+          {
+            "security": False,
+            "release_id": 28,
+            "request": "testing",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 23,
+            "request": "testing",
+            "content_type": "rpm"
+          },
+          {
+            "security": False,
+            "release_id": 31,
+            "request": "testing",
+            "content_type": "flatpak"
+          },
+          {
+            "security": False,
+            "release_id": 8,
+            "request": "testing",
+            "content_type": "rpm"
+          }
+        ]
+      }
     }
 
 

--- a/fedmsg_meta_fedora_infrastructure/tests/bodhi.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/bodhi.py
@@ -2438,6 +2438,109 @@ class TestBodhiMashKickooff(Base):
     }
 
 
+class TestBodhiUpdateFedoraSync(Base):
+    """These messages are published by the new-updates-sync script,
+    which lives in the ansible infra repo in the bodhi backend role,
+    after it syncs the packages from a Fedora updates compose to the
+    master mirror.
+    """
+    expected_title = "bodhi.updates.fedora.sync"
+    expected_subti = "New Fedora 29 updates-testing content synced out " + \
+        "(1 GiB changed with 1259 files deleted)"
+    expected_link = "https://download.fedoraproject.org/pub/fedora/linux/updates/testing/29/Everything/"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/bodhi.png"
+    expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/bodhi.png"
+    expected_usernames = set([])
+    expected_objects = set(['fedora/updates-testing/29'])
+    msg = {
+      "username": "ftpsync",
+      "source_name": "datanommer",
+      "i": 1,
+      "timestamp": 1561603095.0,
+      "msg_id": "2019-2656349c-2c41-48bd-9b66-31b3cd9a5aa9",
+      "crypto": "x509",
+      "topic": "org.fedoraproject.prod.bodhi.updates.fedora.sync",
+      "headers": {},
+      "source_version": "0.9.0",
+      "msg": {
+        "deleted": "1259",
+        "release": "29",
+        "raw_bytes": "2116251621",
+        "bytes": "1 GiB",
+        "repo": "updates-testing"
+      }
+    }
+
+
+class TestBodhiUpdateFedoraSyncModular(Base):
+    """These messages are published by the new-updates-sync script,
+    which lives in the ansible infra repo in the bodhi backend role,
+    after it syncs the packages from a Fedora updates compose to the
+    master mirror. This is how the messages for modular update
+    composes look.
+    """
+    nodoc = True
+    expected_title = "bodhi.updates.fedora.sync"
+    expected_subti = "New Fedora 30 updates modular content synced out " + \
+        "(404 MiB changed with 412 files deleted)"
+    expected_link = "https://download.fedoraproject.org/pub/fedora/linux/updates/30/Modular/"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/bodhi.png"
+    expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/bodhi.png"
+    expected_usernames = set([])
+    expected_objects = set(['fedora/updates/30'])
+    msg = {
+      "username": "ftpsync",
+      "source_name": "datanommer",
+      "i": 1,
+      "timestamp": 1561595377.0,
+      "msg_id": "2019-b7ddfebc-cff4-4dc1-a078-bcf50379b875",
+      "crypto": "x509",
+      "topic": "org.fedoraproject.prod.bodhi.updates.fedora.sync",
+      "headers": {},
+      "source_version": "0.9.0",
+      "msg": {
+        "deleted": "412",
+        "release": "30m",
+        "raw_bytes": "424030490",
+        "bytes": "404 MiB",
+        "repo": "updates"
+      }
+    }
+
+
+class TestBodhiUpdateEPELSync(Base):
+    """These messages are published by the new-updates-sync script,
+    which lives in the ansible infra repo in the bodhi backend role,
+    after it syncs the packages from an EPEL updates compose to the
+    master mirror.
+    """
+    expected_title = "bodhi.updates.epel.sync"
+    expected_subti = "New EPEL 7 epel-testing content synced out " + \
+        "(505 MiB changed with 74 files deleted)"
+    expected_link = "https://download.fedoraproject.org/pub/epel/testing/7/"
+    expected_icon = "https://apps.fedoraproject.org/img/icons/bodhi.png"
+    expected_secondary_icon = "https://apps.fedoraproject.org/img/icons/bodhi.png"
+    expected_usernames = set([])
+    expected_objects = set(['epel/epel-testing/7'])
+    msg = {
+      "username": "ftpsync",
+      "source_name": "datanommer",
+      "i": 3,
+      "timestamp": 1561597841.0,
+      "msg_id": "2019-a31ad980-b626-4685-8aa5-fd4a61a85fb4",
+      "crypto": "x509",
+      "topic": "org.fedoraproject.prod.bodhi.updates.epel.sync",
+      "headers": {},
+      "source_version": "0.9.0",
+      "msg": {
+        "deleted": "74",
+        "release": "7",
+        "raw_bytes": "530049354",
+        "bytes": "505 MiB",
+        "repo": "epel-testing"
+      }
+    }
+
 add_doc(locals())
 
 if __name__ == '__main__':

--- a/fedmsg_meta_fedora_infrastructure/tests/bodhi.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/bodhi.py
@@ -1724,11 +1724,13 @@ class LegacyTestBodhiOverrideUntagged(Base):
     }
 
 
-class TestBodhiStackSave(Base):
+class TestLegacyBodhiStackSave(Base):
     """ `Bodhi2 <https://bodhi.fedoraproject.org>`_ introduced the
     concept of *stacks* of packages that can be grouped for to share
-    requirements.  That system publishes messages like this anytime a user
-    **modifies or creates a new stack**.
+    requirements.  That system published messages like this anytime a user
+    **modified or created a new stack**. This mechanism was removed from
+    Bodhi in January 2019 and exactly one message of this type was ever
+    published in production.
     """
     expected_title = "bodhi.stack.save"
     expected_subti = "ralph updated the \"hacking\" stack"
@@ -1782,11 +1784,12 @@ class TestBodhiStackSave(Base):
     }
 
 
-class TestBodhiStackDelete(Base):
+class TestLegacyBodhiStackDelete(Base):
     """ `Bodhi2 <https://bodhi.fedoraproject.org>`_ introduced the
     concept of *stacks* of packages that can be grouped for to share
-    requirements.  That system publishes messages like this anytime a user
-    **deletes a stack**.
+    requirements.  That system published messages like this anytime a user
+    **deleted a stack**. This mechanism was removed from Bodhi in January
+    2019 and no messages of this type were ever published in production.
     """
     expected_title = "bodhi.stack.delete"
     expected_subti = "ralph deleted the \"hacking\" stack"


### PR DESCRIPTION
This branch started out aiming to make the processor respect the schemas Bodhi now publishes for messages - i.e. only to rely on things which are guaranteed to exist by the schemas. It mostly accomplishes that, plus fixes some other stuff I ran into on the way - messages whose contents have changed, a couple of new message topics, stuff like that. It also factors out some huge `elif` forests to make things a bit easier to follow, though there's not a lot I can do about `subtitle`.