### PR TITLE
added ability to use fasjson when provided with config

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/fasshim.py
+++ b/fedmsg_meta_fedora_infrastructure/fasshim.py
@@ -108,7 +108,7 @@ def make_fasjson_cache(**config):
 
     creds = config['fas_credentials']
 
-    default_url = 'https://admin.fedoraproject.org/accounts/'
+    default_url = 'https://fasjson.fedoraproject.org/v1/'
 
     try:
         client = fasjson_client.Client(url=creds.get('base_url', default_url))

--- a/fedmsg_meta_fedora_infrastructure/fasshim.py
+++ b/fedmsg_meta_fedora_infrastructure/fasshim.py
@@ -106,7 +106,7 @@ def make_fasjson_cache(**config):
         log.warn("No fasjson-client installed.  Not caching fasjson.")
         raise
 
-    creds = config['fas_credentials']
+    creds = config['fasjson_credentials']
 
     default_url = 'https://fasjson.fedoraproject.org/v1/'
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ except Exception:
 
 install_requires = [
     'fedmsg',
-    'fasjson-client',
     'python-fedora',
     'python-dateutil',
     'pytz'
@@ -59,6 +58,17 @@ if sys.version_info < (2, 7):
     ])
     tests_require.extend([
         'unittest2',
+    ])
+
+if sys.version_info >= (3, 6):
+    install_requires.append('fasjson-client')
+else:
+    if sys.version_info < (3,):
+        install_requires.append('pyzmq<19')
+    install_requires.extend([
+        'gssapi<1.6.4',
+        'requests-gssapi',
+        'requests',  # keep this last to appease CI
     ])
 
 entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ except Exception:
 
 install_requires = [
     'fedmsg',
+    'fasjson-client',
     'python-fedora',
     'python-dateutil',
     'pytz'


### PR DESCRIPTION
This commit adds a function which allows the cache to be built using fasjson instead of fas.

there is a difference in how it does this. When using fas it used `python-fedora` to search using the alphabet and a wildcard `a*, b*` etc. Instead of a plain search `fasjson-client` exposes pagination functionality so I have used that.

Signed-off-by: Stephen Coady <scoady@redhat.com>