### PR TITLE
Add information about the namespace in the short description of git messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
  - python setup.py install
  - pip install arrow
 
-script: python setup.py test
+script: python setup.py test -q
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - TRAVIS_CI=True
   jobs:
     - TOXENV=lint
-    - TOXENV=py38
 
 notifications:
     email: false
@@ -23,6 +22,15 @@ notifications:
     on_failure: change
 
 matrix:
+  include:
+   - python: "3.6"
+     env: TOXENV=py36
+   - python: "3.7"
+     env: TOXENV=py37
+   - python: "3.8"
+     env: TOXENV=py38
+   - python: "3.9"
+     env: TOXENV=py39
   allow_failures:
     - python: 2.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,28 @@
 language: python
-python:
- - "2.7"
- - "3.6"
+
 install:
  - pip install --upgrade setuptools pip
  - python setup.py install
  - pip install arrow
+
 script: python setup.py test
-env: TRAVIS_CI=True
+
+env:
+  global:
+    - PYTHONWARNINGS=always::DeprecationWarning
+    - TRAVIS_CI=True
+  jobs:
+    - TOXENV=lint
+    - TOXENV=py38
+
 notifications:
     email: false
     irc:
         - "irc.freenode.net#fedora-apps"
     on_success: change
     on_failure: change
+
+matrix:
+  allow_failures:
+    - python: 2.7
+

--- a/fedmsg_meta_fedora_infrastructure/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/scm.py
@@ -93,6 +93,11 @@ class SCMProcessor(BaseProcessor):
                 repo = '.'.join(msg['topic'].split('.')[5:-1])
 
             try:
+                namespace = msg['msg']['commit']['namespace'] + '/'
+            except KeyError:
+                namespace = ''
+
+            try:
                 user = msg['msg']['commit']['username']
             except KeyError:
                 user = msg['msg']['commit']['email']
@@ -103,8 +108,8 @@ class SCMProcessor(BaseProcessor):
                 summ += " (..more)"
 
             branch = msg['msg']['commit']['branch']
-            tmpl = self._('{user} pushed to {repo} ({branch}).  "{summary}"')
-            return tmpl.format(user=user, repo=repo,
+            tmpl = self._('{user} pushed to {namespace}{repo} ({branch}).  "{summary}"')
+            return tmpl.format(user=user, repo=repo, namespace=namespace,
                                branch=branch, summary=summ)
         elif '.git.branch' in msg['topic']:
             try:
@@ -115,7 +120,7 @@ class SCMProcessor(BaseProcessor):
                 branch = msg['topic'].split('.')[-1]
 
             try:
-                repo = msg['msg']['namespace'] + '/' + repo
+                repo = msg['msg']['commit']['namespace'] + '/' + repo
             except KeyError:
                 pass
 
@@ -211,8 +216,8 @@ class SCMProcessor(BaseProcessor):
     def packages(self, msg, **config):
 
         # If its not an rpms/ thing, then its not a package.
-        if 'namespace' in msg['msg']:
-            if not msg['msg']['namespace'] in ['rpms', 'rpms-checks']:
+        if 'namespace' in msg['msg'].get('commit', []):
+            if not msg['msg']['commit']['namespace'] in ['rpms', 'rpms-checks']:
                 return set()
 
         if 'git.receive' in msg['topic']:

--- a/fedmsg_meta_fedora_infrastructure/tests/scm.py
+++ b/fedmsg_meta_fedora_infrastructure/tests/scm.py
@@ -241,14 +241,70 @@ class TestSCM(Base):
     }
 
 
+class TestSCMWithNamespace(Base):
+    """ Messages like this one are published when somebody runs "fedpkg push"
+    on a package.  Sometimes, the git message may be multiple lines long like:
+    """
+    expected_title = "git.receive"
+    expected_subti = 'mjw pushed to rpms/valgrind (master).  ' + \
+        '"Clear CFLAGS CXXFLAGS LDFLAGS. (..more)"'
+    expected_link = "https://src.fedoraproject.org/rpms/" + \
+        "valgrind/c/" + \
+        "7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1?branch=master"
+    expected_long_form = "This commit already existed in another branch."
+    expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
+    expected_secondary_icon = ("https://seccdn.libravatar.org/avatar/"
+        "0f32874b1ae3083205c874c83cd2d21715c89b8645483f353e90ae499c67c944"
+        "?s=64&d=retro")
+    expected_usernames = set(['mjw'])
+    expected_packages = set(['valgrind'])
+    expected_objects = set(['valgrind/valgrind.spec'])
+
+    msg = {
+        "i": 1,
+        "timestamp": 1344350850.8867381,
+        "topic": "org.fedoraproject.prod.git.receive",
+        "msg": {
+            "commit": {
+                "seen": True,
+                "stats": {
+                    "files": {
+                        "valgrind.spec": {
+                            "deletions": 2,
+                            "lines": 3,
+                            "insertions": 1
+                        }
+                    },
+                    "total": {
+                        "deletions": 2,
+                        "files": 1,
+                        "insertions": 1,
+                        "lines": 3
+                    }
+                },
+                "name": "Mark Wielaard",
+                "rev": "7a98f80d9b61ce167e4ef8129c81ed9284ecf4e1",
+                "summary": "Clear CFLAGS CXXFLAGS LDFLAGS.",
+                "message": """Clear CFLAGS CXXFLAGS LDFLAGS.
+                This is a bit of a hammer.""",
+                "email": "mjw@redhat.com",
+                "username": "mjw",
+                "branch": "master",
+                "repo": "valgrind",
+                "namespace": "rpms",
+            }
+        }
+    }
+
+
 class TestSCMSingleLine(Base):
     """ Messages like this one are published when somebody runs "fedpkg push"
     on a package.  The whole git message is included for each commit.
     """
     expected_title = "git.receive"
-    expected_subti = 'spot pushed to ember (master).  ' + \
+    expected_subti = 'spot pushed to tests/ember (master).  ' + \
         '"another missing patch? ridiculous."'
-    expected_link = "https://src.fedoraproject.org/rpms/" + \
+    expected_link = "https://src.fedoraproject.org/tests/" + \
         "ember/c/" + \
         "aa2df80f3d8dd217c7cbfe2d3451190028f3fe14?branch=master"
     expected_icon = "https://apps.fedoraproject.org/img/icons/git-logo.png"
@@ -256,7 +312,7 @@ class TestSCMSingleLine(Base):
         "1e232310ef80ec8b34b0bc216864efd0d837f419e6988997cda8e98a28be48dd"
         "?s=64&d=retro")
     expected_usernames = set(['spot'])
-    expected_packages = set(['ember'])
+    expected_packages = set()
     expected_objects = set(['ember/ember-0.6.3-gcc47.patch'])
 
     msg = {
@@ -286,6 +342,7 @@ class TestSCMSingleLine(Base):
                 "summary": "another missing patch? ridiculous.",
                 "branch": "master",
                 "repo": "ember",
+                "namespace": "tests",
                 "message": "another missing patch? ridiculous.\n",
                 "email": "spot@fedoraproject.org"
             }


### PR DESCRIPTION
Currently the short description was talking about the git push to a repo
but did not include the namespace of the repo. This commit fixes that.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>