### PR TITLE
Pass along unrecognized reason instead of saying I dunno. Whatever".

### DIFF
--- a/fedmsg_meta_fedora_infrastructure/hotness.py
+++ b/fedmsg_meta_fedora_infrastructure/hotness.py
@@ -109,7 +109,7 @@ class HotnessProcessor(BaseProcessor):
                 'rawhide': self._("no rawhide version of the "
                                   "package could be found yet")
             }
-            errmsg = self._('.... I dunno.  Whatever.')
+            errmsg = self._('reason unrecognized: ' + reason)
             return prefix.format(thing=thing) + qualifiers.get(reason, errmsg)
         elif 'hotness.project.map' in msg['topic']:
             original = msg['msg']['trigger']['msg']


### PR DESCRIPTION
I got an email with the Subject
```
the-new-hotness saw an update for singularity, but .... I dunno.       Whatever.
```
That comes from it being an unrecognized reason, but I can't tell what that reason was because it is hidden.  This changes the code to pass along that unrecognized reason so it can hopefully become recognized at some point.  (I think in my case a likely error was that a bugzilla issue was already filed, but that was supposed to have been one of the recognized reasons.)

- Fixes fedora-infra/the-new-hotness#379